### PR TITLE
I've updated cui-parent to 1.1.0 and set the baseline to Java 21.

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,5 +2,5 @@ name: cui-test-generator
 pages-reference: cui-test-generator
 sonar-project-key: cuioss_cui-test-generator
 release:
-  current-version: 2.3.1
-  next-version: 2.4-SNAPSHOT
+  current-version: 2.4.0
+  next-version: 2.5.0-SNAPSHOT

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -31,10 +31,10 @@ jobs:
           metadata-file-path: '.github/project.yml'
           local-file: true
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 17,21,24 ]
+        version: [ 21,24 ]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -28,7 +28,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven, Java ${{ matrix.version }}
-        run: ./mvnw --no-transfer-progress verify -Dmaven.compiler.source=${{ matrix.version }} -Dmaven.compiler.target=${{ matrix.version }}
+        run: ./mvnw --no-transfer-progress verify -Dmaven.compiler.release=${{ matrix.version }}
 
   sonar-build:
     needs: build
@@ -44,10 +44,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 17 for Sonar-build
+      - name: Set up JDK 21 for Sonar-build
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 
@@ -83,10 +83,10 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Set up JDK 17 for snapshot release
+      - name: Set up JDK 21 for snapshot release
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           server-id: central
           server-username: MAVEN_USERNAME

--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@
 
 image:https://github.com/cuioss/cui-test-generator/actions/workflows/maven.yml/badge.svg[Java CI with Maven,link=https://github.com/cuioss/cui-test-generator/actions/workflows/maven.yml]
 image:http://img.shields.io/:license-apache-blue.svg[License,link=http://www.apache.org/licenses/LICENSE-2.0.html]
-image:https://maven-badges.herokuapp.com/maven-central/de.cuioss.test/cui-test-generator/badge.svg[Maven Central,link=https://maven-badges.herokuapp.com/maven-central/de.cuioss.test/cui-test-generator]
+image:https://img.shields.io/maven-central/v/de.cuioss.test/cui-test-generator.svg?label=Maven%20Central["Maven Central", link="https://central.sonatype.com/artifact/de.cuioss.test/cui-test-generator"]
 
 https://sonarcloud.io/summary/new_code?id=cuioss_cui-test-generator[image:https://sonarcloud.io/api/project_badges/measure?project=cuioss_cui-test-generator&metric=alert_status[Quality Gate Status]]
 image:https://sonarcloud.io/api/project_badges/measure?project=cuioss_cui-test-generator&metric=ncloc[Lines of Code,link=https://sonarcloud.io/summary/new_code?id=cuioss_cui-test-generator]

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>0.9.9.6</version>
+        <version>1.1.0</version>
         <relativePath />
     </parent>
     <groupId>de.cuioss.test</groupId>


### PR DESCRIPTION
Here's what I did:
- Updated cui-parent to version 1.1.0 in pom.xml.
- Updated GitHub workflows (maven.yml, maven-release.yml) to use Java 21 as the baseline, removing Java 17.
- Replaced deprecated maven.compiler.source/target with maven.compiler.release in maven.yml.
- Incremented project version in .github/project.yml to 2.4.0 (next version 2.5.0-SNAPSHOT).
- Updated Maven Central badge in README.adoc to the new shields.io format.
- Verified the build with `./mvnw clean install`.