### PR TITLE
chore: add git workflow documentation to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,3 +110,15 @@ Each approach uses an `ArgumentsProvider` implementation that:
 - Java 21+ required (configured via parent POM)
 - Dependencies managed through cui-java-parent POM
 - Main dependencies: JUnit 5, Lombok, cui-java-tools
+
+## Git Workflow
+
+This repository has branch protection on `main`. Direct pushes to `main` are never allowed. Always use this workflow:
+
+1. Create a feature branch: `git checkout -b <branch-name>`
+2. Commit changes: `git add <files> && git commit -m "<message>"`
+3. Push the branch: `git push -u origin <branch-name>`
+4. Create a PR: `gh pr create --head <branch-name> --base main --title "<title>" --body "<body>"`
+5. Wait for CI: `gh pr checks --watch`
+6. Merge when checks pass: `gh pr merge --squash --delete-branch`
+7. Return to main: `git checkout main && git pull`


### PR DESCRIPTION
## Summary
- Add git workflow section to CLAUDE.md documenting branch protection requirements
- Documents that direct push to main is never allowed and the required branch+PR workflow