### PR TITLE
chore: prepare next release - update parent POM to 1.4.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,7 +2,7 @@ name: cui-test-generator
 description: CUI Test Generator - provides generators for testing
 
 release:
-  current-version: 2.5.1
+  current-version: 2.5.2
   next-version: 2.6-SNAPSHOT
   create-github-release: true
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-java-parent</artifactId>
-        <version>1.3.3</version>
+        <version>1.4.0</version>
         <relativePath />
     </parent>
     <groupId>de.cuioss.test</groupId>


### PR DESCRIPTION
## Summary
- Update cui-java-parent from 1.3.3 to 1.4.0
- Increment release current-version to 2.5.2

## Test plan
- [x] `./mvnw -Ppre-commit clean install` passes with 627 tests, 0 failures, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)