### PR TITLE
chore: configure dependency propagation

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -25,3 +25,12 @@ pages:
 
 github-automation:
   auto-merge-build-versions: true
+
+consumers:
+  - cuioss-parent-pom:version.cui.test.generator
+  - nifi-extensions:version.cui.test.generator
+
+dependency-propagation:
+  group-id: de.cuioss.test
+  artifact-id: cui-test-generator
+  scope: dependency


### PR DESCRIPTION
## Summary
- Add `consumers` and `dependency-propagation` config to `project.yml`
- On release, propagates version to `cuioss-parent-pom` (property `version.cui.test.generator`) and `nifi-extensions`

## Test plan
- [ ] CI build passes (config-only change to project.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)