### PR TITLE
docs: full project review with partitioned fix plan (review-26-07-04)

### DIFF
--- a/doc/review-26-07-04.md
+++ b/doc/review-26-07-04.md
@@ -1,0 +1,213 @@
+# Project Review — cui-test-generator — 2026-07-04
+
+Full-project analysis covering all main packages, the test suite, build configuration, and
+documentation. This document contains **findings and a fix plan only** — no fixes have been
+applied. Each finding has a stable ID for traceability; the fix plan at the end partitions the
+work into PR clusters with a defined workflow per PR.
+
+**Baseline:** `main` @ `7c33e69`. `./mvnw -Ppre-commit clean install` passes
+(450 tests, 0 failures), but the OpenRewrite AutoFormat recipe modifies two committed files
+(see B-1), i.e. the tree is not formatter-clean.
+
+Severity legend: **critical** = broken feature / actively misleading; **major** = incorrect
+behavior or contract violation with real user impact; **minor** = quality, robustness,
+documentation.
+
+---
+
+## 1. Findings
+
+### A. Seed management & reproducibility (S-*)
+
+| ID | Sev | Location | Finding | Fix hint |
+|----|-----|----------|---------|----------|
+| S-1 | major | `internal/RandomContext.java:33-99`, `junit/GeneratorControllerExtension.java:106-126` | The documented replay mechanism `-Dde.cuioss.test.generator.seed=<seed>` does not reproduce a single failing test: the property seeds the RNG once in the static initializer, but `beforeEach` unconditionally calls `initSeed()` (absent `@GeneratorSeed`), drawing `nextLong()` and re-seeding — the effective per-test seed is derived, not the reported `lastSeed`. Replay only works for a full run with identical test order. | Make the extension honor the system property directly as the per-test seed (remember the property value in `RandomContext`), or correct the failure message/docs to describe full-run replay. |
+| S-2 | minor | `internal/RandomContext.java:94-98` | `Long.parseLong` on the seed property runs in the static initializer; a malformed value (`=abc`) surfaces as `ExceptionInInitializerError` + follow-up `NoClassDefFoundError` for the whole run. | Catch `NumberFormatException` in `readSystemProperty()`; fail with a clear message or warn and fall back to a random seed. |
+| S-3 | minor | `internal/RandomContext.java:48-49,81-83` | `lastSeed` is a non-volatile static long (stale/torn reads under parallel execution), and its default `0L` is reported by `getLastSeed()` even though seed 0 was never applied to the unseeded `Random`. | Declare `lastSeed` volatile; ensure a real seed is captured at initialization so the reported value always matches actual RNG state. |
+| S-4 | major | `junit/parameterized/AbstractTypedGeneratorArgumentsProvider.java:63-77` | The `if (useSeed != previousSeed)` guard skips `setSeed` when an explicitly requested seed (annotation or `@GeneratorSeed`) happens to equal `lastSeed`; generation then continues mid-stream, so arguments depend on what earlier tests consumed — the exact non-reproducibility seeds are meant to prevent. | Always `setSeed(useSeed)` when an explicit seed was resolved; only skip re-seeding in the fallback case where the seed *is* `getLastSeed()`. |
+| S-5 | major | `junit/parameterized/TypeGeneratorMethodArgumentsProvider.java:52-88` | Unlike all sibling providers, this class implements `ArgumentsProvider` directly and performs **no seed handling** — `@GeneratorSeed` is ignored for `@TypeGeneratorMethodSource`, contradicting its Javadoc ("Seed management is integrated…"). Its `getSeed()` is dead API and the generation loop duplicates `generateArguments()`. | Extend `AbstractTypedGeneratorArgumentsProvider`; implement `provideArgumentsForGenerators`/`getSeed`/`getCount`; delete the hand-rolled loop. |
+| S-6 | minor | `junit/parameterized/AbstractTypedGeneratorArgumentsProvider.java:72-77` | The finally-block "restore" calls `setSeed(previousSeed)`, rewinding the shared RNG to the *start* of the previous seed's sequence, so subsequent code replays values already produced. | `java.util.Random` position can't be restored — either document the replay behavior or re-seed with a freshly derived seed (`initSeed()`). |
+| S-7 | minor | `junit/GeneratorControllerExtension.java:114-115` | Class-level `@GeneratorSeed` lookup uses `method.getDeclaringClass()` — misses the annotation on the concrete class for inherited test methods and on enclosing classes for `@Nested` tests. | Use `context.getRequiredTestClass()` plus enclosing-class traversal (e.g. `AnnotationSupport.findAnnotation`). |
+| S-8 | major | `junit/GeneratorControllerExtension.java:94-102` | `handleTestExecutionException` wraps the original throwable into a new `AssertionFailedError` without setting it as cause (only stack trace copied): cause chain and suppressed exceptions are lost, `expected`/`actual` ValueWrappers are discarded (breaks IDE diffs), and non-assertion errors are re-typed as assertion failures. | Use the cause-preserving constructors: `new AssertionFailedError(msg, cause)` and `new AssertionFailedError(msg, expected, actual, cause)` for the AFE branch. |
+| S-9 | minor | `junit/GeneratorControllerExtension.java:100` | `throwable.getClass() + ": "` produces messages prefixed with a spurious `class ` (e.g. `class java.lang.NullPointerException: …`). | Use `throwable.getClass().getName()`. |
+
+### B. Parameterized-source providers & GeneratorType (J-*)
+
+| ID | Sev | Location | Finding | Fix hint |
+|----|-----|----------|---------|----------|
+| J-1 | **critical** | `junit/parameterized/CompositeTypeGeneratorArgumentsProvider.java:206-217` | `createGeneratorFromType` calls `Generators.class.getMethod(generatorType.getMethodName())`; for all 13 `DOMAIN_*` constants `getMethodName()` is `null`, so `getMethod(null)` NPEs (wrapped in a generic message). **Every domain generator is unusable with `@CompositeTypeGeneratorSource`.** | Mirror `GeneratorsSourceArgumentsProvider`: when `methodName == null`, instantiate `getFactoryClass()` via `JpmsReflectionHelper.newGeneratorInstance` (extract shared helper, see J-4). |
+| J-2 | major | `junit/parameterized/GeneratorType.java:183` | `FIXED_VALUES("fixedValues", …, PARAMETERLESS)` maps to a zero-arg `Generators.fixedValues()` that does not exist (all 4 overloads take parameters). Any use fails with `NoSuchMethodException`; the constant is unusable and untested (see T-1a). | Remove the constant (there is no annotation mechanism to pass the fixed values), or design a value-passing mechanism first. |
+| J-3 | minor | `junit/parameterized/CompositeTypeGeneratorArgumentsProvider.java:208-213` | `createGeneratorFromType` ignores `getParameterType()`; NEEDS_BOUNDS/NEEDS_RANGE types only work because zero-arg overloads happen to exist, silently using full-range defaults that differ from `@GeneratorsSource` semantics. | Share the type-dispatch logic of `GeneratorsSourceArgumentsProvider.createGeneratorFromFactory` via a common helper. |
+| J-4 | minor | `junit/parameterized/GeneratorMethodResolver.java:80-87` | The precise `JUnitException` ("Cannot invoke instance method … without a test instance") is thrown inside the `try` and immediately re-wrapped by `catch (Exception)` into the generic "Failed to invoke method", burying the diagnostic. | Do the null-instance check before the try block, or rethrow non-JPMS `JUnitException`s unwrapped. |
+| J-5 | minor | `junit/parameterized/GeneratorsSourceArgumentsProvider.java:78-82,98-103` | Reflection failures wrapped in message-less `IllegalStateException` (inconsistent with the `JUnitException` convention elsewhere), hiding the target exception two levels deep; Javadoc claims `@throws JUnitException` while the signature declares reflection exceptions. | Wrap in `JUnitException` with the generator type in the message; unwrap `InvocationTargetException.getTargetException()`; align Javadoc. |
+| J-6 | minor | `junit/parameterized/TypeGeneratorFactoryArgumentsProvider.java:137-150` | With multiple same-name/same-arity factory overloads returning `TypedGenerator`, selection falls back to `candidateMethods.getFirst()` with unspecified `getMethods()` order — nondeterministic overload choice failing later with an obscure `IllegalArgumentException`. | Filter to all-String-parameter methods up front (parameters are always Strings); throw a clear ambiguity/no-match `JUnitException` otherwise. |
+| J-7 | minor | `junit/parameterized/AbstractTypedGeneratorArgumentsProvider.java:48,189-195` | `IN_CLASS` constant and `findMethod(...)` helper are used by no subclass — dead duplicates of identical members in `GeneratorMethodResolver`. | Delete both from the abstract class. |
+| J-8 | minor | `junit/parameterized/CompositeTypeGeneratorArgumentsProvider.java:176-184` | Size-mismatch check in `createOneToOnePairs` is dead code: every value list is built with exactly `count` elements. | Remove the check. |
+| J-9 | minor | `junit/parameterized/GeneratorsSourceArgumentsProvider.java:179-184` | Short/Byte branches in `createNumberGenerator` are unreachable (no NEEDS_RANGE `GeneratorType` returns Short/Byte) and would fail anyway (`Generators` has no such range overloads). | Remove the branches (or add overloads + enum constants deliberately). |
+| J-10 | minor | `junit/parameterized/GeneratorType.java:60-223` | Class Javadoc claims "all available generator types", but `enumValues`, `uniqueValues`, and the domain enums `OrganizationNameGenerator`, `TitleGenerator`, `NameGenerators` have no constants (the factory-class mechanism cannot represent enum-based generators). | Soften the Javadoc to the supported subset, or add wrapper support for the missing generators. |
+
+### C. Core generator implementations (C-*)
+
+| ID | Sev | Location | Finding | Fix hint |
+|----|-----|----------|---------|----------|
+| C-1 | major | `impl/DoubleGenerator.java:63-67` | Fallback branch (`max == Double.MAX_VALUE`): `nextDouble() * (max - min) + min` overflows — for `new DoubleGenerator(-Double.MAX_VALUE, Double.MAX_VALUE)`, `max - min` is `Infinity`, producing `Infinity` (or `NaN` when `nextDouble()` is 0.0), violating the documented `[min, max]` bound. `max` is also effectively exclusive in this branch despite the "inclusive" contract. | Use the JDK's overflow-safe bounded algorithm (halve origin/bound when the span is infinite, cf. `Random.nextDouble(origin,bound)` internals) and map boundary rounding back to `max`. |
+| C-2 | minor | `impl/DoubleGenerator.java:50-56` | Constructor accepts NaN/infinite bounds (`max < min` is false for NaN); failure surfaces later inside `next()` instead of failing fast. | Validate `Double.isFinite(min) && Double.isFinite(max)` in the constructor. |
+| C-3 | major | `Generators.java:395-446`, `impl/DoubleGenerator.java:39`, `impl/FloatObjectGenerator.java:51` | No-arg `doubles()`/`floats()`/`doubleObjects()`/`floatObjects()` can never produce negative values or zero: default lower bound is `Double.MIN_VALUE`/`Float.MIN_VALUE` (smallest *positive* value), while constructors claim "full double/float range". | **Decision needed:** change default lower bound to `-Double.MAX_VALUE`/`-Float.MAX_VALUE` (behavior change, requires C-1 first) **or** document the positive-only behavior loudly. Recommendation: fix the behavior; positive-only "full range" is a trap. |
+| C-4 | major | `impl/LongGenerator.java:79-83` | `bigDecimalImpl()` (used for spans > `Long.MAX_VALUE`, i.e. default `longs()`, `longObjects()`, transitively `DateGenerator`) derives the long from a single `nextDouble()` — 53 mantissa bits over a 2^64 span means only ~every 2048th value is reachable and `Long.MAX_VALUE` never occurs. | Use `nextLong()` directly for the full-range case, or combine two bounded draws. Note: changes the value stream for fixed seeds (call out in release notes). |
+| C-5 | major | `impl/StringGenerator.java:51-71`, `Generators.java:195` | `strings(chars,minSize,maxSize)` documents `@throws IllegalArgumentException … if either is negative`, but negative sizes are not rejected; a negative drawn length makes `new StringBuilder(length)` throw `NegativeArraySizeException` *intermittently*. | Validate `minSize >= 0` in both `StringGenerator` constructors (and align `IntegerGenerator` usage), throwing IAE. |
+| C-6 | major | `impl/UniqueValuesGenerator.java:37,48-59` | `seen` is a plain `HashSet` mutated in `next()` — violates the framework's explicit thread-safety contract (`TypedGenerator` L71, `Generators` L64); concurrent use can corrupt the set or yield duplicates. | Use `ConcurrentHashMap.newKeySet()` (or qualify the thread-safety claims, see E-16). |
+| C-7 | minor | `impl/UniqueValuesGenerator.java:30-36` | Lombok `@RequiredArgsConstructor` exposes `(source, maxRetries)` unvalidated: `maxRetries <= 0` always throws confusingly in `next()`; null `source` isn't rejected at construction despite documented NPE. | Replace with explicit constructor: `requireNonNull(source)`, `maxRetries > 0`. |
+| C-8 | minor | `Generators.java:223-232` | `letterStrings()` draws its **fixed** max size once at factory-call time from the shared seeded RNG (consuming a draw) — every instance has one max; doc suggests per-call variation. Also typo "mininmal". | Delegate to `letterStrings(3, 256)` for per-call variation, or document the fixed-max behavior; fix typo. |
+| C-9 | minor | `Generators.java:585-600` | `timeZones()`/`zoneIds()` rebuild the full ~600-entry zone list on every invocation; `zoneIds()` duplicates logic already cached in `ZoneOffsetGenerator.ZONE_IDS_GEN`. | Cache the lists in static finals and reuse. |
+| C-10 | minor | `Generators.java:709-725` | `determineSupertypeFromIterable` returns the concrete class of the *first element* (not a supertype); heterogeneous input yields a `getType()` not applicable to all values; NPEs on a null first element. | Rename/document accurately; guard null first element with a clear message. |
+| C-11 | minor | `Generators.java:143-148` | `enumValues` documents `@throws IllegalArgumentException if type is not an enum`, but a non-enum (via raw types) produces an NPE from `Arrays.asList(getEnumConstants())`. | Validate `type.isEnum()` and throw IAE (or fix the `@throws` doc). |
+| C-12 | minor | `impl/URLGenerator.java:57`, `impl/PrimitiveArrayGenerators.java:216` | `static final` fields `generator` / `sizeGenerator` use instance naming, inconsistent with sibling constants (`DELEGATE`, `ZONE_IDS_GEN`). | Rename to UPPER_SNAKE_CASE. |
+
+### D. Domain generators (D-*)
+
+| ID | Sev | Location | Finding | Fix hint |
+|----|-----|----------|---------|----------|
+| D-1 | minor | `domain/MailSubjectGenerator.java:70,73` | `for (var i = 0; i < prefixCountGenerator.next(); i++)` re-draws the bound on every loop iteration (same for content): distribution is not the documented uniform 0-3/0-7, and 1-8 extra draws are consumed per `next()`. | Hoist the counts into locals before the loops. |
+| D-2 | minor | `domain/EmailGenerator.java:78` | `toLowerCase()` uses the default locale — on a Turkish-locale JVM "Isabella" → dotless `ı`, producing invalid, locale-dependent emails. | Use `toLowerCase(Locale.ROOT)`. |
+| D-3 | minor | `domain/EmailGenerator.java:63-76` | `createEmail` `@param` docs say names "must not be null or empty", but the code accepts them with a fallback; docs say "empty" while code checks `isBlank()`; no sanitization of spaces/apostrophes despite the "syntactically valid" class promise. | Reword the contract to describe lenient fallback (or throw); consider sanitizing the local part. |
+| D-4 | minor | `domain/PersonGenerator.java:58-60` | Null-check-and-warn on `firstname`/`lastname` is dead code — `FixedValuesGenerator` over non-empty lists never returns null. | Remove the dead check (and the Logger if unused). |
+| D-5 | minor | `domain/BlindTextGenerator`, `EmailGenerator`, `FullNameGenerator`, `MailSubjectGenerator`, `PersonGenerator`, `UUIDGenerator` | These six rely on default `TypedGenerator.getType()`, which calls `next()` — a `getType()` call silently consumes shared-RNG draws (~6 for `PersonGenerator`), shifting the deterministic stream; siblings all override statically. | Override `getType()` to return `String.class`/`UUID.class`/`Person.class` directly. |
+| D-6 | minor | `domain/ZipCodeGenerator.java:46` | Field `zibCodes` is a typo for `zipCodes`. | Rename. |
+| D-7 | minor | `domain/ZipCodeGenerator.java:26-46` | Javadoc claims official German postal format incl. leading zeros (`%05d`), but range 10000-99999 never needs leading zeros and excludes all valid 01xxx-09xxx codes (e.g. Dresden 01067). | Generate zero-padded strings over 1067-99999, or correct the Javadoc. |
+| D-8 | minor | `domain/DistinguishedNamesGenerator.java:60` | Values list contains `"dc"` (one of the attribute *prefixes*), yielding odd components like `ou=dc` — looks like an accidental copy. | Remove/replace the value. |
+| D-9 | minor | `domain/FullNameGenerator.java:65` | `Locale.GERMAN.equals(locale)` — `Locale.GERMANY`/de_AT/de_CH silently get English names. | Compare `"de".equals(locale.getLanguage())` with a null guard. |
+| D-10 | minor | `domain/UUIDGenerator.java:33-35` | UUIDs built from two raw longs without RFC 4122 version/variant bits — `uuid.version()`/`variant()` are garbage; validators of v4 UUIDs reject them while `UUIDStringGenerator` advertises "valid UUID string". | **Decision needed:** mask in version-4/variant bits (behavior change for fixed seeds) or document arbitrary 128-bit UUIDs. Recommendation: set the bits. |
+
+### E. Documentation & Javadoc (E-*)
+
+| ID | Sev | Location | Finding | Fix hint |
+|----|-----|----------|---------|----------|
+| E-1 | **critical** | `CLAUDE.md:118-133` | "Git Workflow" contains two overlapping numbered sequences with directly contradictory instructions: steps 4-7 say enable auto-merge + poll; the following steps 4-8 say "Do NOT enable auto-merge… Wait for user approval." | Delete the first block (old steps 4-7) and renumber so only the newer workflow (PR with `--repo`, `gh pr checks --watch`, Gemini handling, no auto-merge) remains. |
+| E-2 | minor | `CLAUDE.md:112` | "Main dependencies: … cui-java-tools" — not declared in the POM, no `de.cuioss.tools` import exists. | Drop it (actual deps: JUnit 5, Lombok; EasyMock test-only). |
+| E-3 | major | `junit/parameterized/GeneratorsSource.java:114-126` | Javadoc example uses `seed = 42L`, but `@GeneratorsSource` has **no `seed` attribute** — the documented example does not compile. | **Decision needed:** add `long seed() default -1L` (provider currently hard-returns -1; small code change, consistent with `@TypeGeneratorSource`) or remove the example and reference `@GeneratorSeed`. Recommendation: add the attribute. |
+| E-4 | major | `junit/parameterized/package-info.java:32-64` | Claims "All annotations in this package support … seed" (only `@TypeGeneratorSource` does), and the "Available Annotations" list omits `@GeneratorsSource` — the recommended annotation. | Correct the seed claim (align with E-3 outcome); add the missing list entry. |
+| E-5 | major | `src/site/asciidoc/about.adoc:93` | Tells users to replay with `-Dio.cui.test.generator.seed=4711`, but the real property is `de.cuioss.test.generator.seed` — the documented property is never read. | Fix the property name (align with S-1 outcome). |
+| E-6 | minor | `src/site/asciidoc/about.adoc:64-65` | Example uses `Generators.enumValues(PropertyMemberInfo.class)` — class from another project, not compilable here. | Use e.g. `TimeUnit.class`. |
+| E-7 | minor | `junit/package-info.java:40-42`, `junit/EnableGeneratorController.java:46` | Examples contain `new CollectionGenerator&lt;?&gt;(…)` (wildcard instantiation, invalid Java), literal `&amp;lt;&amp;gt;` entities inside `{@code}` (rendered verbatim), and AssertJ assertions though AssertJ is not a dependency. | Use `new CollectionGenerator<>(…)`, plain `<>` inside `{@code}`, JUnit assertions. |
+| E-8 | minor | `README.adoc:25-31` | Maven coordinates snippet has no `<version>` and no BOM note — copy-paste into a standalone POM fails. | Add a version element or a note about cui-java-bom management. |
+| E-9 | minor | `junit/parameterized/GeneratorsSource.java:131` + all `impl/*` classes | `@GeneratorsSource` tagged `@since 2.0` but its mandatory attribute type `GeneratorType` is `@since 2.3`; separately, none of the 23 public `impl` classes has any `@since` tag. | Align to 2.3; add `@since` tags to public impl classes. |
+| E-10 | major | `Generators.java:238-245` | `fixedValues` example asserts sequential cycling (`"A"`, `"B"`, "cycles back"), but `FixedValuesGenerator` selects **randomly** — the documented assertions are false. | Rewrite to assert membership in the supplied set. |
+| E-11 | minor | `Generators.java` (117-124, 203-210, 246-266, 513-518) | `enumValuesIfAvailable` documents NPE though null is handled; `strings()` claims values "may be null" (never null); `fixedValues(Class,T...)` missing `@param type`, varargs overload missing `@throws` for empty/null-first-element; `longs(long,long)` says "primitives" (returns boxed). | Correct each tag/wording. |
+| E-12 | major | `impl/CollectionGenerator.java:58,93-96` | Class example `Collection<Integer> coll = collectionGen.next();` doesn't compile — `next()` returns a single `T`; constructor param docs garbled ("determines the of {@link Collection} size", twice). | Fix example (`Integer value = …` / point to `list()`/`set()`); reword params. |
+| E-13 | minor | `impl/ZonedDateTimeGenerator.java:91-131` | Copy-paste `@return` docs: `someMinutesAgo` says "one hour ago"; all `some*Ago` claim "one X ago" but subtract random 1-10; `lastTenYearsAgo`/`lastMonthAgo` say "somewhere" but return fixed offsets. | Correct to "between 1 and 10 <unit>s ago" / "exactly N <unit>(s) ago". |
+| E-14 | minor | `impl/package-info.java:53,82-84` | Example calls `dateTimeGen.future()` — method doesn't exist; "Non-empty string generation" should be "non-blank"; CollectionGenerator snippet duplicated. | Use an existing method; fix wording; deduplicate. |
+| E-15 | minor | `impl/URLGenerator.java:31,49-50` | Class doc self-contradicts: "All URLs are valid **and accessible**" vs. "does not guarantee … reachable". | Drop "and accessible". |
+| E-16 | major | `Generators.java:62-64`, `domain/UUIDStringGenerator.java:26`, `domain/package-info.java:62-65` | Blanket "thread-safe **and** reproducible" claims are jointly unsatisfiable: all generators share one `Random`, so concurrent use interleaves draws and destroys seed reproducibility — the headline feature. | Qualify everywhere: thread-safe for generation; reproducibility guaranteed only for single-threaded execution. |
+| E-17 | minor | `TypedGenerator.java:61-67` | Default `getType()` documents `IllegalStateException` on null, but implementation NPEs on the first null; the call also consumes an RNG draw (undocumented side effect). | Correct `@throws`; document the draw-consuming side effect (relates to D-5). |
+| E-18 | minor | `impl/StringGenerator.java:23-25` | Claims default chars come from "Basic Latin and Latin-1 Supplement", but the range is 0x20-0x7E — printable Basic Latin only. | Correct the doc. |
+| E-19 | minor | `impl/PrimitiveArrayGenerators.java:219,229-239` | `resolveForType` documents only `IllegalStateException` but throws undocumented IAE (non-primitive) and NPE (null); typo "an primitive array". | Add `@throws` tags; fix typo. |
+
+### T. Test suite (T-*)
+
+| ID | Sev | Location | Finding | Fix hint |
+|----|-----|----------|---------|----------|
+| T-1 | major | `GenerateArgumentsTest.java:73-94` | `shouldGenerateArgumentsWithConsistentSeed` uses a `FixedStringGenerator` that always returns the same value — passes even if seed handling is completely broken. | Use a real random generator; reset seed between two runs; assert equal argument lists. |
+| T-1a | major | coverage gap | `GeneratorType.FIXED_VALUES` is exercised by no test — which is why J-2 went unnoticed. | Covered by J-2's regression test (expect removal or working mapping). |
+| T-2 | major | `AbstractTypedGeneratorArgumentsProviderTest.java:81-86,197-211` | `shouldDetermineSeedFromAnnotation` short-circuits before any annotation logic (explicit seed 42); the `@GeneratorSeed` resolution branches are untested and the fixtures built for them are unused. | Test with `getSeed() == -1` and mocked contexts using the existing fixtures; rename the current test. |
+| T-3 | major | `impl/ByteGeneratorTest.java:27-35` | Asserts `byte >= Byte.MIN_VALUE && <= Byte.MAX_VALUE` — tautologically true for every byte. | Assert falsifiable properties (sign coverage in a sample, seed reproducibility). |
+| T-4 | major | all of `impl/`, `domain/`, `internal/` tests + `GeneratorsTest` | CLAUDE.md mandates `@EnableGeneratorController` for generator tests; **no** test class in these packages uses it; several set `RandomContext.setSeed` directly and leak global seed state across classes. | Add `@EnableGeneratorController` to all generator test classes. |
+| T-5 | major | coverage gap | Seed-reproducibility tests exist only for Integer/Long/UUID/UUIDString generators; all other generators have none, violating project guidance. | Add per-generator reproducibility cases or one parameterized test over `GeneratorType.values()`. |
+| T-6 | major | coverage gap | No dedicated test class for `LocalDateGenerator`, `LocalDateTimeGenerator`, `LocalTimeGenerator`, `ZoneOffsetGenerator`, `URLGenerator`, `ShortObjectGenerator`, `DecoratorGenerator`, `NumberGenerator`, `FloatObjectGenerator` — only incidental `assertNotNull` smoke coverage. | Add dedicated tests asserting constraints (ranges, URL wellformedness, delegation, NPE contracts). |
+| T-7 | minor | `domain/DomainGeneratorTest.java:29-163` | Every test is `assertNotNull` on structurally non-null values — no format/content assertions. | Assert domain properties (zip range, DN structure, name contains space, phone pattern). |
+| T-8 | minor | `GeneratorsTest.java:172-369` | ~25 pure `assertNotNull(x.next())` tests on auto-boxed primitives; bounded overloads (`integers(1,31)` etc.) never assert bounds. | Fold into a parameterized smoke test; assert bounds on bounded overloads. |
+| T-9 | minor | `GeneratorsSourceTest.java:49-61`, `CompositeTypeGeneratorSourceTest.java:94-107`, `TypeGeneratorFactorySourceTest.java:68-78`, `TypeGeneratorIntegrationTest.java:59-66` | Seed-specific tests assert only `assertNotNull` — seed application never verified (one comment even admits it). | With a fixed seed, assert the concrete deterministic values. |
+| T-10 | minor | `junit/GeneratorControllerExtensionWOSeedInfoTest.java:28-36` | Only assertion is `assertNotEquals(0, getLastSeed())` against a global any earlier test may have set. | Record seed per repetition; assert it changes between repetitions. |
+| T-11 | minor | `impl/ComplexBean.java` | 100+-line fixture referenced by no test — dead code. | Delete (or actually use). |
+| T-12 | minor | `GenerateArgumentsTest.java:43-60,128-156` + 3 files | `TestProvider` near-duplicates `AbstractTypedGeneratorArgumentsProviderTest`'s; `TestFactoryClass` copy-pasted into three files. | Extract shared package-private fixtures; drop the duplicated test. |
+| T-13 | minor | `TypeGeneratorIntegrationTest.java:69-77,98-111` | `LocalDate.now()` computed both in generator retry loop and assertion — midnight rollover can fail the boundary; rejection loop spins unboundedly over the full LocalDate range. | Capture `now` once; widen window or bound the generator range. |
+| T-14 | minor | `impl/NonBlankStringGeneratorTest.java:63-86` | Two tests re-assert properties already implied by `!isBlank()` under distinct names. | Collapse; add distinguishing assertions (length bounds, reproducibility). |
+| T-15 | minor | coverage gap | `TypedGenerator`'s default `getType()` has no direct test (its documented failure behavior is also wrong, see E-17). | Add lambda-based tests for type inference and null behavior. |
+
+### B. Build (B-*)
+
+| ID | Sev | Location | Finding | Fix hint |
+|----|-----|----------|---------|----------|
+| B-1 | minor | `impl/PrimitiveArrayGenerators.java`, `domain/OrganizationNameGenerator.java` | `./mvnw -Ppre-commit clean install` reformats both files via OpenRewrite AutoFormat — the committed sources are not formatter-compliant, so every contributor build produces a dirty tree. | Run the pre-commit profile and commit the resulting formatting. |
+
+---
+
+## 2. Fix plan — PR clusters
+
+Findings are partitioned into 7 PRs, ordered so that behavior decisions land before the
+documentation that describes them, and each bug-fix PR carries its own regression tests.
+**Two clusters contain explicit decision points (marked ⚠); resolve them at PR time
+(recommendations given in the findings) — they change generated value streams for fixed
+seeds and should be called out in release notes.**
+
+### Standard workflow for every PR
+
+1. `git checkout main && git pull`, then `git checkout -b <branch>`.
+2. Implement the cluster's fixes **including regression tests** for every code-level finding.
+3. `export JAVA_HOME=$HOME/.sdkman/candidates/java/current && ./mvnw -Ppre-commit clean install` — must be green **and** leave a clean tree.
+4. Commit with a descriptive message referencing the finding IDs (e.g. `fix: honor explicit seeds in argument providers (S-4, S-5)`), push: `git push -u origin <branch>`.
+5. Create the PR against `main` (title referencing the cluster, body listing the finding IDs).
+6. **Wait ~5 minutes** for CI and the Gemini review to complete (`gh pr checks --watch`).
+7. Handle **every** review comment: fix + reply, or reply with reasoning why not — then resolve the thread. If uncertain about a suggestion, ask the user before acting.
+8. Merge (squash) once CI is green and all threads are resolved; delete the branch; `git checkout main && git pull`.
+9. Tick the cluster off in the *Progress* section below (update this document on `main` or in the next PR).
+
+### PR 1 — `fix/formatting-compliance` (trivial, do first)
+**Findings:** B-1.
+Run the pre-commit build, commit the two auto-formatted files. Zero functional change; also
+validates the full PR workflow cheaply.
+
+### PR 2 — `fix/seed-management` — seed handling & extension error reporting
+**Findings:** S-1…S-9 (files: `RandomContext`, `GeneratorControllerExtension`,
+`AbstractTypedGeneratorArgumentsProvider`, `TypeGeneratorMethodArgumentsProvider`).
+**Tests to add:** replay-via-property test (S-1); malformed-property test (S-2); explicit-seed-equals-lastSeed regression (S-4); `@GeneratorSeed` on `@TypeGeneratorMethodSource` (S-5); inherited/`@Nested` `@GeneratorSeed` (S-7); cause/expected-actual preservation (S-8). Also fixes T-1 and T-2 (same subject area).
+⚠ S-1 defines the replay semantics that E-5's doc fix must match — record the decision in the PR description.
+
+### PR 3 — `fix/parameterized-providers` — provider bugs & diagnostics
+**Findings:** J-1…J-10.
+**Tests to add:** `@CompositeTypeGeneratorSource` with a `DOMAIN_*` type (J-1); `FIXED_VALUES` removal/regression (J-2/T-1a); factory-overload ambiguity (J-6); exception-type/message assertions (J-4, J-5). Extract the shared generator-creation helper (J-1/J-3) rather than duplicating dispatch logic.
+Note: removing `GeneratorType.FIXED_VALUES` (J-2) is an API removal — mention in release notes.
+
+### PR 4 — `fix/core-generators` — impl correctness
+**Findings:** C-1…C-12.
+**Tests to add:** full-range double bounds incl. `[-MAX, MAX]` (C-1); NaN/infinite-bounds rejection (C-2); sign coverage for `doubles()`/`floats()` (C-3); full-range long distribution smoke + `MAX_VALUE` reachability property (C-4); negative-size IAE (C-5); concurrent `uniqueValues` (C-6); constructor validation (C-7).
+⚠ C-3 and C-4 change generated sequences for fixed seeds — decide and document (recommendations: fix behavior).
+
+### PR 5 — `fix/domain-generators` — domain correctness
+**Findings:** D-1…D-10.
+**Tests to add:** count distribution/draw count (D-1); locale-safe email (D-2); `getType()` consumes no draw (D-5); zip format (D-7); DN components (D-8); `Locale.GERMANY` names (D-9); UUID version/variant (D-10). Also upgrades `DomainGeneratorTest` assertions it touches (part of T-7).
+⚠ D-10 changes generated UUIDs for fixed seeds — decide and document (recommendation: set RFC 4122 bits).
+
+### PR 6 — `docs/javadoc-and-guides` — documentation truthfulness
+**Findings:** E-1…E-19 (must land **after** PR 2/4/5 so docs describe the decided behavior; E-3's recommended resolution — adding `seed()` to `@GeneratorsSource` — is a small code+test change and lives here or in PR 2, either is fine as long as docs and code land together).
+**Verification:** `./mvnw javadoc:javadoc` clean; every corrected example must compile (spot-check by pasting into a scratch test).
+
+### PR 7 — `test/suite-hardening` — test quality & coverage
+**Findings:** T-3…T-15 (T-1/T-2 in PR 2, T-1a in PR 3; parts of T-7 in PR 5).
+Adopt `@EnableGeneratorController` across generator tests (T-4), add reproducibility coverage (T-5), dedicated tests for the nine untested impl classes (T-6), strengthen weak assertions (T-3, T-7…T-10, T-14), remove dead/duplicated fixtures (T-11, T-12), de-flake the date test (T-13), cover default `getType()` (T-15).
+
+### Progress
+
+- [ ] PR 1 — formatting compliance (B-1)
+- [ ] PR 2 — seed management (S-1…S-9, T-1, T-2)
+- [ ] PR 3 — parameterized providers (J-1…J-10, T-1a)
+- [ ] PR 4 — core generators (C-1…C-12)
+- [ ] PR 5 — domain generators (D-1…D-10)
+- [ ] PR 6 — documentation (E-1…E-19)
+- [ ] PR 7 — test suite hardening (T-3…T-15)
+
+---
+
+## 3. Final verification & document removal
+
+After all seven PRs are merged:
+
+1. Re-run the full analysis checklist: for **every** finding ID above, open the referenced
+   location on `main` and verify the defect is gone (or an explicit, documented decision was
+   made to keep the behavior — record which).
+2. Run `./mvnw -Ppre-commit clean install` from a clean checkout — must be green with a clean
+   tree (proves B-1 stays fixed).
+3. Run `./mvnw javadoc:javadoc` — no warnings from the corrected docs.
+4. Only when **all** findings are verified fixed (or consciously waived with a recorded
+   reason): open a final PR that **removes this document** (`doc/review-26-07-04.md`), using
+   the same PR workflow. If any finding is not fixed, keep the document, update the Progress
+   section, and continue instead.

--- a/doc/review-26-07-04.md
+++ b/doc/review-26-07-04.md
@@ -17,7 +17,7 @@ documentation.
 
 ## 1. Findings
 
-### A. Seed management & reproducibility (S-*)
+### S. Seed management & reproducibility (S-*)
 
 | ID | Sev | Location | Finding | Fix hint |
 |----|-----|----------|---------|----------|
@@ -31,7 +31,7 @@ documentation.
 | S-8 | major | `junit/GeneratorControllerExtension.java:94-102` | `handleTestExecutionException` wraps the original throwable into a new `AssertionFailedError` without setting it as cause (only stack trace copied): cause chain and suppressed exceptions are lost, `expected`/`actual` ValueWrappers are discarded (breaks IDE diffs), and non-assertion errors are re-typed as assertion failures. | Use the cause-preserving constructors: `new AssertionFailedError(msg, cause)` and `new AssertionFailedError(msg, expected, actual, cause)` for the AFE branch. |
 | S-9 | minor | `junit/GeneratorControllerExtension.java:100` | `throwable.getClass() + ": "` produces messages prefixed with a spurious `class ` (e.g. `class java.lang.NullPointerException: …`). | Use `throwable.getClass().getName()`. |
 
-### B. Parameterized-source providers & GeneratorType (J-*)
+### J. Parameterized-source providers & GeneratorType (J-*)
 
 | ID | Sev | Location | Finding | Fix hint |
 |----|-----|----------|---------|----------|


### PR DESCRIPTION
## Summary

Adds `doc/review-26-07-04.md` — the result of a full project analysis covering all main packages (`impl`, `domain`, `junit`, `junit.parameterized`, `internal`), the test suite, build configuration, and documentation.

The document contains **findings and a fix plan only**; no fixes are applied in this PR. Highlights:

- **66 consolidated findings** with stable IDs, severity, exact location, and fix hints
- 2 critical items: all `DOMAIN_*` generator types are unusable with `@CompositeTypeGeneratorSource` (NPE on `getMethod(null)`), and CLAUDE.md contains two contradictory Git workflow sequences
- Several major seed-reproducibility defects (broken `-Dde.cuioss.test.generator.seed` replay, seed guard skipping re-seed, `@TypeGeneratorMethodSource` ignoring `@GeneratorSeed`)
- Generator correctness issues (`DoubleGenerator` Infinity/NaN overflow, positive-only "full range" doubles/floats, biased full-range longs, non-RFC-4122 UUIDs)
- Documentation examples that do not compile and contracts contradicting the code
- Test-suite gaps (tautological assertions, missing `@EnableGeneratorController` adoption, nine untested impl classes)

## Fix plan

The work is partitioned into **7 PR clusters** (formatting → seed management → parameterized providers → core generators → domain generators → documentation → test hardening), each with the standard workflow (feature branch, green `-Ppre-commit` build, PR, ~5 min wait for CI + Gemini review, handle every comment, squash-merge), plus a final verification step that removes the document once every finding is verified fixed.

Baseline: `main` @ 7c33e69 — build and all 450 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKRnUNRxCnt6iGxmuxy97f

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKRnUNRxCnt6iGxmuxy97f)_