### PR TITLE
fix: seed management &amp; extension error reporting (S-1..S-9, T-1, T-2)

### DIFF
--- a/src/main/java/de/cuioss/test/generator/internal/RandomContext.java
+++ b/src/main/java/de/cuioss/test/generator/internal/RandomContext.java
@@ -17,7 +17,9 @@ package de.cuioss.test.generator.internal;
 
 import lombok.experimental.UtilityClass;
 
+import java.util.Optional;
 import java.util.Random;
+import java.util.logging.Logger;
 
 /**
  * Manages the shared {@link Random} instance and seed state for all generators.
@@ -45,11 +47,30 @@ public class RandomContext {
      */
     public static final String SEED_SYSTEM_PROPERTY = "de.cuioss.test.generator.seed";
 
+    private static final Logger LOGGER = Logger.getLogger(RandomContext.class.getName());
+
     static final Random random = new Random(); // NOSONAR: not about cryptography
-    static long lastSeed = 0L;
+
+    /**
+     * The last seed applied to {@link #random}. Volatile so that concurrent readers
+     * always observe the value actually applied to the shared RNG.
+     */
+    static volatile long lastSeed;
+
+    /**
+     * The seed configured via {@link #SEED_SYSTEM_PROPERTY}, or {@code null} if the
+     * property is absent or malformed. Evaluated once at class initialization.
+     */
+    private static final Long CONFIGURED_SEED = readSystemProperty();
 
     static {
-        readSystemProperty();
+        if (CONFIGURED_SEED != null) {
+            setSeed(CONFIGURED_SEED);
+        } else {
+            // Capture a concrete seed up-front so getLastSeed() always reflects the
+            // actual state of the shared RNG (never the misleading default 0L).
+            setSeed(random.nextLong());
+        }
     }
 
     /**
@@ -91,10 +112,32 @@ public class RandomContext {
         return random;
     }
 
-    static void readSystemProperty() {
+    /**
+     * Returns the seed configured via {@link #SEED_SYSTEM_PROPERTY}, if any.
+     * <p>
+     * When present, this seed is meant to be applied directly as the per-test seed so
+     * that a failing test can be reproduced by re-running the whole suite with the
+     * property set.
+     * </p>
+     *
+     * @return the configured seed, or an empty {@link Optional} if the property is
+     *         absent or could not be parsed
+     */
+    public static Optional<Long> getConfiguredSeed() {
+        return Optional.ofNullable(CONFIGURED_SEED);
+    }
+
+    static Long readSystemProperty() {
         var seed = System.getProperty(SEED_SYSTEM_PROPERTY);
-        if (seed != null) {
-            setSeed(Long.parseLong(seed));
+        if (seed == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(seed.trim());
+        } catch (NumberFormatException e) {
+            LOGGER.warning(() -> "Ignoring malformed value '" + seed + "' for system property '"
+                    + SEED_SYSTEM_PROPERTY + "'; falling back to a random seed.");
+            return null;
         }
     }
 }

--- a/src/main/java/de/cuioss/test/generator/junit/GeneratorControllerExtension.java
+++ b/src/main/java/de/cuioss/test/generator/junit/GeneratorControllerExtension.java
@@ -19,10 +19,12 @@ import de.cuioss.test.generator.internal.RandomContext;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.junit.platform.commons.support.AnnotationSupport;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
+import org.opentest4j.ValueWrapper;
 
-import java.lang.reflect.Method;
+import java.util.Optional;
 
 /**
  * JUnit 5 extension that manages test data generation by controlling generator seeds
@@ -91,39 +93,74 @@ public class GeneratorControllerExtension implements BeforeEachCallback, TestExe
         if (throwable instanceof TestAbortedException) {
             throw throwable;
         }
-        if (throwable instanceof AssertionFailedError) {
-            var failure = new AssertionFailedError(createErrorMessage(throwable, RandomContext.getLastSeed()));
-            failure.setStackTrace(throwable.getStackTrace());
+        var seed = RandomContext.getLastSeed();
+        if (throwable instanceof AssertionFailedError afe) {
+            var message = createErrorMessage(afe, seed);
+            AssertionFailedError failure;
+            if (afe.isExpectedDefined() || afe.isActualDefined()) {
+                failure = new AssertionFailedError(message, unwrap(afe.getExpected()), unwrap(afe.getActual()), afe);
+            } else {
+                failure = new AssertionFailedError(message, afe);
+            }
+            copyTrace(afe, failure);
             throw failure;
         }
         var failure = new AssertionFailedError(
-                throwable.getClass() + ": " + createErrorMessage(throwable, RandomContext.getLastSeed()));
-        failure.setStackTrace(throwable.getStackTrace());
+                throwable.getClass().getName() + ": " + createErrorMessage(throwable, seed), throwable);
+        copyTrace(throwable, failure);
         throw failure;
+    }
 
+    private static Object unwrap(ValueWrapper wrapper) {
+        return wrapper == null ? null : wrapper.getValue();
+    }
+
+    private static void copyTrace(Throwable source, Throwable target) {
+        target.setStackTrace(source.getStackTrace());
+        for (var suppressed : source.getSuppressed()) {
+            target.addSuppressed(suppressed);
+        }
     }
 
     @Override
-    @SuppressWarnings("java:S3655") // owolff: false positive: isPresent is checked
     public void beforeEach(ExtensionContext context) {
-        var seedSetByAnnotation = false;
-        long initialSeed = -1;
-        if (context.getElement().isPresent()) {
-            var annotatedElement = context.getElement().get();
-            var seedAnnotation = annotatedElement.getAnnotation(GeneratorSeed.class);
-            if (null == seedAnnotation && annotatedElement instanceof Method method) {
-                seedAnnotation = method.getDeclaringClass().getAnnotation(GeneratorSeed.class);
-            }
-            if (null != seedAnnotation) {
-                initialSeed = seedAnnotation.value();
-                seedSetByAnnotation = true;
-            }
-        }
-        if (seedSetByAnnotation) {
-            RandomContext.setSeed(initialSeed);
+        var seedAnnotation = findSeedAnnotation(context);
+        if (seedAnnotation.isPresent()) {
+            RandomContext.setSeed(seedAnnotation.get().value());
         } else {
-            RandomContext.initSeed();
+            // Honor the replay system property as the per-test seed so that re-running
+            // with -D<property>=<seed> reproduces a single failing test; otherwise draw
+            // a fresh random seed.
+            var configuredSeed = RandomContext.getConfiguredSeed();
+            if (configuredSeed.isPresent()) {
+                RandomContext.setSeed(configuredSeed.get());
+            } else {
+                RandomContext.initSeed();
+            }
         }
+    }
+
+    /**
+     * Resolves the applicable {@link GeneratorSeed} by walking outward from the current
+     * context: the test method first, then each enclosing class (covering {@code @Nested}
+     * tests), honoring annotations inherited on the concrete test class.
+     *
+     * @param context the extension context
+     * @return the closest {@link GeneratorSeed}, or empty if none is present
+     */
+    private static Optional<GeneratorSeed> findSeedAnnotation(ExtensionContext context) {
+        for (Optional<ExtensionContext> current = Optional.ofNullable(context);
+             current.isPresent();
+             current = current.get().getParent()) {
+            var element = current.get().getElement();
+            if (element.isPresent()) {
+                var found = AnnotationSupport.findAnnotation(element.get(), GeneratorSeed.class);
+                if (found.isPresent()) {
+                    return found;
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     private String createErrorMessage(Throwable e, Long seed) {

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProvider.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProvider.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.support.AnnotationSupport;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -120,31 +121,37 @@ public abstract class AbstractTypedGeneratorArgumentsProvider implements Argumen
      * <ol>
      *   <li>Seed specified in the source annotation (if not {@code -1})</li>
      *   <li>Seed from {@code @GeneratorSeed} on the test method</li>
-     *   <li>Seed from {@code @GeneratorSeed} on the test class</li>
+     *   <li>Seed from {@code @GeneratorSeed} on the (possibly enclosing or inherited) test class</li>
      * </ol>
-     * When none of these is present, no explicit seed is requested and the shared RNG is
-     * left untouched (an empty result), so generation continues from the seed established
-     * by the enclosing {@code @EnableGeneratorController} for the current test.
+     * The class hierarchy is walked outward from the current context — matching
+     * {@code GeneratorControllerExtension} — so {@code @Nested} tests and annotations
+     * inherited on a concrete subclass are honored. When none of these is present, no
+     * explicit seed is requested and the shared RNG is left untouched (an empty result),
+     * so generation continues from the seed established by the enclosing
+     * {@code @EnableGeneratorController} for the current test.
      *
      * @param context the extension context
      * @return the explicitly requested seed, or empty if none was requested
      */
-    @SuppressWarnings("java:S3655") // False positive, isPresent() is checked
     protected OptionalLong resolveExplicitSeed(ExtensionContext context) {
         long seed = getSeed();
         if (seed != -1L) {
             return OptionalLong.of(seed);
         }
 
-        if (context != null && context.getElement().isPresent()
-                && context.getElement().get() instanceof Method method) {
-            var methodAnnotation = method.getAnnotation(GeneratorSeed.class);
-            if (methodAnnotation != null) {
-                return OptionalLong.of(methodAnnotation.value());
-            }
-            var classAnnotation = method.getDeclaringClass().getAnnotation(GeneratorSeed.class);
-            if (classAnnotation != null) {
-                return OptionalLong.of(classAnnotation.value());
+        for (Optional<ExtensionContext> current = Optional.ofNullable(context);
+             current.isPresent();
+             current = current.get().getParent()) {
+            var element = current.get().getElement();
+            if (element.isPresent()) {
+                var found = AnnotationSupport.findAnnotation(element.get(), GeneratorSeed.class);
+                if (found.isEmpty() && element.get() instanceof Method method) {
+                    // The declaring class is not part of a method's own annotation search
+                    found = AnnotationSupport.findAnnotation(method.getDeclaringClass(), GeneratorSeed.class);
+                }
+                if (found.isPresent()) {
+                    return OptionalLong.of(found.get().value());
+                }
             }
         }
 

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProvider.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProvider.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
@@ -59,20 +60,20 @@ public abstract class AbstractTypedGeneratorArgumentsProvider implements Argumen
     public Stream<? extends Arguments> provideArguments(
             ParameterDeclarations parameters,
             ExtensionContext context) throws Exception {
-        // Handle seed management
-        var previousSeed = RandomContext.getLastSeed();
-        var useSeed = determineSeed(context);
-
-        if (useSeed != previousSeed) {
-            RandomContext.setSeed(useSeed);
-        }
+        // Apply an explicitly requested seed (annotation attribute or @GeneratorSeed)
+        // unconditionally, so that reproducibility never depends on what earlier tests
+        // happened to consume from the shared RNG.
+        var explicitSeed = resolveExplicitSeed(context);
+        explicitSeed.ifPresent(RandomContext::setSeed);
 
         try {
             return provideArgumentsForGenerators(context);
         } finally {
-            // Restore previous seed if we changed it
-            if (useSeed != previousSeed) {
-                RandomContext.setSeed(previousSeed);
+            if (explicitSeed.isPresent()) {
+                // The position of java.util.Random cannot be restored; re-seeding with the
+                // previous seed would replay its stream. Advance to a fresh random seed so
+                // later consumers do not observe a rewound RNG.
+                RandomContext.initSeed();
             }
         }
     }
@@ -115,44 +116,50 @@ public abstract class AbstractTypedGeneratorArgumentsProvider implements Argumen
     }
 
     /**
-     * Determines the seed to use for the generator based on the following priority:
-     * 1. Seed specified in the annotation (if not -1)
-     * 2. Seed from @GeneratorSeed on the test method
-     * 3. Seed from @GeneratorSeed on the test class
-     * 4. Current global seed from RandomContext
+     * Resolves an explicitly requested seed, based on the following priority:
+     * <ol>
+     *   <li>Seed specified in the source annotation (if not {@code -1})</li>
+     *   <li>Seed from {@code @GeneratorSeed} on the test method</li>
+     *   <li>Seed from {@code @GeneratorSeed} on the test class</li>
+     * </ol>
+     * When none of these is present, no explicit seed is requested and the shared RNG is
+     * left untouched (an empty result), so generation continues from the seed established
+     * by the enclosing {@code @EnableGeneratorController} for the current test.
+     *
+     * @param context the extension context
+     * @return the explicitly requested seed, or empty if none was requested
+     */
+    @SuppressWarnings("java:S3655") // False positive, isPresent() is checked
+    protected OptionalLong resolveExplicitSeed(ExtensionContext context) {
+        long seed = getSeed();
+        if (seed != -1L) {
+            return OptionalLong.of(seed);
+        }
+
+        if (context != null && context.getElement().isPresent()
+                && context.getElement().get() instanceof Method method) {
+            var methodAnnotation = method.getAnnotation(GeneratorSeed.class);
+            if (methodAnnotation != null) {
+                return OptionalLong.of(methodAnnotation.value());
+            }
+            var classAnnotation = method.getDeclaringClass().getAnnotation(GeneratorSeed.class);
+            if (classAnnotation != null) {
+                return OptionalLong.of(classAnnotation.value());
+            }
+        }
+
+        return OptionalLong.empty();
+    }
+
+    /**
+     * Determines the seed to use for the generator, falling back to the current global
+     * seed from {@link RandomContext} when no explicit seed was requested.
      *
      * @param context the extension context
      * @return the seed to use
      */
-    @SuppressWarnings("java:S3655") // False positive, isPresent() is checked
     protected long determineSeed(ExtensionContext context) {
-        // If seed is explicitly set in the annotation, use it
-        long seed = getSeed();
-        if (seed != -1L) {
-            return seed;
-        }
-
-        // Check for @GeneratorSeed on method or class
-        if (context.getElement().isPresent()) {
-            var element = context.getElement().get();
-
-            // Check method first
-            if (element instanceof Method method) {
-                var seedAnnotation = method.getAnnotation(GeneratorSeed.class);
-                if (seedAnnotation != null) {
-                    return seedAnnotation.value();
-                }
-
-                // Then check class
-                var classAnnotation = method.getDeclaringClass().getAnnotation(GeneratorSeed.class);
-                if (classAnnotation != null) {
-                    return classAnnotation.value();
-                }
-            }
-        }
-
-        // Fall back to current global seed
-        return RandomContext.getLastSeed();
+        return resolveExplicitSeed(context).orElseGet(RandomContext::getLastSeed);
     }
 
     /**

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/TypeGeneratorMethodArgumentsProvider.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/TypeGeneratorMethodArgumentsProvider.java
@@ -16,15 +16,11 @@
 package de.cuioss.test.generator.junit.parameterized;
 
 import de.cuioss.test.generator.TypedGenerator;
-import lombok.Getter;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
-import org.junit.jupiter.params.support.ParameterDeclarations;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -44,16 +40,22 @@ import java.util.stream.Stream;
  * <li>A method in the test class</li>
  * <li>A static method in another class</li>
  * </ul>
+ *
+ * <p>
+ * Seed management (including {@link de.cuioss.test.generator.junit.GeneratorSeed})
+ * is inherited from {@link AbstractTypedGeneratorArgumentsProvider}.
+ * </p>
+ *
  * @author Oliver Wolff
  * @see TypeGeneratorMethodSource
  * @see TypedGenerator
  * @since 2.0
  */
-public class TypeGeneratorMethodArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<TypeGeneratorMethodSource> {
+public class TypeGeneratorMethodArgumentsProvider extends AbstractTypedGeneratorArgumentsProvider
+        implements AnnotationConsumer<TypeGeneratorMethodSource> {
 
     private String methodName;
 
-    @Getter
     private int count;
 
     @Override
@@ -63,26 +65,25 @@ public class TypeGeneratorMethodArgumentsProvider implements ArgumentsProvider, 
     }
 
     @Override
-    public Stream<? extends Arguments> provideArguments(
-            ParameterDeclarations parameters,
-            ExtensionContext context) {
-        // Get the TypedGenerator from the method
+    protected Stream<? extends Arguments> provideArgumentsForGenerators(ExtensionContext context) {
         var generator = GeneratorMethodResolver.getGenerator(methodName, context);
-
-        // Generate values
-        List<Arguments> arguments = new ArrayList<>();
-        for (int i = 0; i < count; i++) {
-            arguments.add(Arguments.of(generator.next()));
-        }
-
-        return arguments.stream();
+        return generateArguments(generator).stream();
     }
 
     /**
-     * @return the seed value used for this provider
+     * {@code @TypeGeneratorMethodSource} carries no seed attribute; reproducibility is
+     * driven exclusively by {@code @GeneratorSeed}, handled by the base class.
+     *
+     * @return {@code -1L}, signalling no source-level seed
      */
-    public long getSeed() {
+    @Override
+    protected long getSeed() {
         return -1L;
+    }
+
+    @Override
+    protected int getCount() {
+        return count;
     }
 
 }

--- a/src/test/java/de/cuioss/test/generator/internal/RandomContextTest.java
+++ b/src/test/java/de/cuioss/test/generator/internal/RandomContextTest.java
@@ -59,4 +59,57 @@ class RandomContextTest {
         Random random = RandomContext.random();
         assertNotNull(random);
     }
+
+    @Test
+    @DisplayName("parse a valid, whitespace-padded seed system property")
+    void shouldParseValidSeedProperty() {
+        withProperty(" 4711 ", () ->
+                assertEquals(4711L, RandomContext.readSystemProperty()));
+    }
+
+    @Test
+    @DisplayName("fall back to no seed on a malformed seed system property")
+    void shouldFallBackOnMalformedSeedProperty() {
+        withProperty("not-a-number", () ->
+                assertNull(RandomContext.readSystemProperty(),
+                        "A malformed property must not raise, but fall back to a random seed"));
+    }
+
+    @Test
+    @DisplayName("report no seed when the system property is absent")
+    void shouldReportNoSeedWhenPropertyAbsent() {
+        var property = RandomContext.SEED_SYSTEM_PROPERTY;
+        var previous = System.getProperty(property);
+        System.clearProperty(property);
+        try {
+            assertNull(RandomContext.readSystemProperty());
+        } finally {
+            restore(property, previous);
+        }
+    }
+
+    @Test
+    @DisplayName("expose the configured seed as an Optional")
+    void shouldExposeConfiguredSeed() {
+        assertNotNull(RandomContext.getConfiguredSeed());
+    }
+
+    private static void withProperty(String value, Runnable assertion) {
+        var property = RandomContext.SEED_SYSTEM_PROPERTY;
+        var previous = System.getProperty(property);
+        System.setProperty(property, value);
+        try {
+            assertion.run();
+        } finally {
+            restore(property, previous);
+        }
+    }
+
+    private static void restore(String property, String previous) {
+        if (previous == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, previous);
+        }
+    }
 }

--- a/src/test/java/de/cuioss/test/generator/junit/GeneratorControllerExtensionTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/GeneratorControllerExtensionTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.test.generator.junit;
 
 import de.cuioss.test.generator.internal.RandomContext;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
@@ -81,6 +82,57 @@ class GeneratorControllerExtensionTest {
             assertNotSame(exception, e);
             assertInstanceOf(AssertionFailedError.class, e);
             assertTrue(e.getMessage().contains(String.valueOf(DEFAULT_SEED)));
+        }
+    }
+
+    // cui-rewrite:disable InvalidExceptionUsageRecipe
+    @Test
+    void shouldPreserveCauseExpectedAndActual() {
+        var original = new AssertionFailedError("boom", "the-expected", "the-actual");
+        var extension = new GeneratorControllerExtension();
+        RandomContext.setSeed(DEFAULT_SEED);
+        try {
+            extension.handleTestExecutionException(null, original);
+            fail("Should have thrown exception");
+        } catch (Throwable e) {
+            var afe = assertInstanceOf(AssertionFailedError.class, e);
+            assertSame(original, afe.getCause(), "Original assertion must be preserved as cause");
+            assertTrue(afe.isExpectedDefined());
+            assertTrue(afe.isActualDefined());
+            assertEquals("the-expected", afe.getExpected().getValue());
+            assertEquals("the-actual", afe.getActual().getValue());
+            assertTrue(afe.getMessage().contains(String.valueOf(DEFAULT_SEED)));
+        }
+    }
+
+    // cui-rewrite:disable InvalidExceptionUsageRecipe
+    @Test
+    void shouldPreserveCauseForNonAssertionErrorWithoutClassPrefix() {
+        var original = new IllegalStateException("bad state");
+        var extension = new GeneratorControllerExtension();
+        RandomContext.setSeed(DEFAULT_SEED);
+        try {
+            extension.handleTestExecutionException(null, original);
+            fail("Should have thrown exception");
+        } catch (Throwable e) {
+            assertInstanceOf(AssertionFailedError.class, e);
+            assertSame(original, e.getCause(), "Original throwable must be preserved as cause");
+            assertTrue(e.getMessage().startsWith("java.lang.IllegalStateException:"),
+                    "Message must use the qualified class name without a spurious 'class ' prefix");
+            assertFalse(e.getMessage().startsWith("class "));
+        }
+    }
+
+    /**
+     * Verifies that a {@code @Nested} test without its own seed inherits the
+     * enclosing class-level {@code @GeneratorSeed} (S-7).
+     */
+    @Nested
+    class NestedWithoutOwnSeed {
+
+        @Test
+        void shouldInheritEnclosingClassSeed() {
+            assertEquals(5L, RandomContext.getLastSeed());
         }
     }
 }

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProviderTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProviderTest.java
@@ -97,6 +97,7 @@ class AbstractTypedGeneratorArgumentsProviderTest {
         var method = TestClass.class.getMethod("methodWithSeed");
         ExtensionContext context = createMock(ExtensionContext.class);
         expect(context.getElement()).andReturn(Optional.of((AnnotatedElement) method)).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         assertEquals(OptionalLong.of(123L), provider.resolveExplicitSeed(context));
@@ -110,6 +111,7 @@ class AbstractTypedGeneratorArgumentsProviderTest {
         var method = ClassWithSeed.class.getMethod("methodWithoutSeed");
         ExtensionContext context = createMock(ExtensionContext.class);
         expect(context.getElement()).andReturn(Optional.of((AnnotatedElement) method)).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         assertEquals(OptionalLong.of(456L), provider.resolveExplicitSeed(context));
@@ -123,6 +125,7 @@ class AbstractTypedGeneratorArgumentsProviderTest {
         var method = TestClass.class.getMethod("wrongReturnType");
         ExtensionContext context = createMock(ExtensionContext.class);
         expect(context.getElement()).andReturn(Optional.of((AnnotatedElement) method)).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         assertEquals(OptionalLong.empty(), provider.resolveExplicitSeed(context));

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProviderTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProviderTest.java
@@ -17,6 +17,7 @@ package de.cuioss.test.generator.junit.parameterized;
 
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.TypedGenerator;
+import de.cuioss.test.generator.internal.RandomContext;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.GeneratorSeed;
 import org.junit.jupiter.api.DisplayName;
@@ -28,11 +29,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.JUnitException;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Stream;
 
+import static org.easymock.EasyMock.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -79,10 +83,74 @@ class AbstractTypedGeneratorArgumentsProviderTest {
     }
 
     @Test
-    @DisplayName("Should determine seed from annotation")
-    void shouldDetermineSeedFromAnnotation() {
+    @DisplayName("Should prefer an explicit source-level seed over any annotation")
+    void shouldPreferExplicitSourceSeed() {
         var provider = new TestProvider(TEST_SEED, 1);
         assertEquals(TEST_SEED, provider.determineSeed(null));
+        assertEquals(OptionalLong.of(TEST_SEED), provider.resolveExplicitSeed(null));
+    }
+
+    @Test
+    @DisplayName("Should resolve seed from @GeneratorSeed on the test method")
+    void shouldResolveSeedFromMethodAnnotation() throws Exception {
+        var provider = new TestProvider(-1L, 1);
+        var method = TestClass.class.getMethod("methodWithSeed");
+        ExtensionContext context = createMock(ExtensionContext.class);
+        expect(context.getElement()).andReturn(Optional.of((AnnotatedElement) method)).anyTimes();
+        replay(context);
+
+        assertEquals(OptionalLong.of(123L), provider.resolveExplicitSeed(context));
+        verify(context);
+    }
+
+    @Test
+    @DisplayName("Should resolve seed from class-level @GeneratorSeed when method has none")
+    void shouldResolveSeedFromClassAnnotation() throws Exception {
+        var provider = new TestProvider(-1L, 1);
+        var method = ClassWithSeed.class.getMethod("methodWithoutSeed");
+        ExtensionContext context = createMock(ExtensionContext.class);
+        expect(context.getElement()).andReturn(Optional.of((AnnotatedElement) method)).anyTimes();
+        replay(context);
+
+        assertEquals(OptionalLong.of(456L), provider.resolveExplicitSeed(context));
+        verify(context);
+    }
+
+    @Test
+    @DisplayName("Should report no explicit seed and fall back to the global seed when unannotated")
+    void shouldFallBackToGlobalSeedWhenNoAnnotation() throws Exception {
+        var provider = new TestProvider(-1L, 1);
+        var method = TestClass.class.getMethod("wrongReturnType");
+        ExtensionContext context = createMock(ExtensionContext.class);
+        expect(context.getElement()).andReturn(Optional.of((AnnotatedElement) method)).anyTimes();
+        replay(context);
+
+        assertEquals(OptionalLong.empty(), provider.resolveExplicitSeed(context));
+        RandomContext.setSeed(987654321L);
+        assertEquals(987654321L, provider.determineSeed(context));
+        verify(context);
+    }
+
+    @Test
+    @DisplayName("Should re-apply an explicit seed even when it equals the current global seed")
+    void shouldReapplyExplicitSeedEqualToLastSeed() throws Exception {
+        long seed = 987654321L;
+        var generator = Generators.integers(Integer.MIN_VALUE, Integer.MAX_VALUE);
+
+        // Baseline: three values from the very start of the seed's stream
+        RandomContext.setSeed(seed);
+        var baseline = List.of(generator.next(), generator.next(), generator.next());
+
+        // Advance the shared RNG mid-stream while lastSeed still equals the explicit seed
+        RandomContext.setSeed(seed);
+        RandomContext.random().nextInt();
+        assertEquals(seed, RandomContext.getLastSeed());
+
+        var provider = new GeneratingProvider(seed, 3, generator);
+        var produced = provider.provideArguments(null, null).map(a -> a.get()[0]).toList();
+
+        assertEquals(baseline, produced,
+                "Explicit seed must be re-applied so arguments do not depend on prior consumption");
     }
 
     @ParameterizedTest(name = "With count={0}, should generate {0} arguments")
@@ -143,6 +211,37 @@ class AbstractTypedGeneratorArgumentsProviderTest {
 
         public List<Arguments> generateArgumentsPublic(TypedGenerator<?> generator) {
             return generateArguments(generator);
+        }
+    }
+
+    /**
+     * Provider that actually generates arguments from a supplied generator, used to
+     * observe seed application end-to-end.
+     */
+    private static class GeneratingProvider extends AbstractTypedGeneratorArgumentsProvider {
+        private final long seed;
+        private final int count;
+        private final TypedGenerator<?> generator;
+
+        GeneratingProvider(long seed, int count, TypedGenerator<?> generator) {
+            this.seed = seed;
+            this.count = count;
+            this.generator = generator;
+        }
+
+        @Override
+        protected Stream<? extends Arguments> provideArgumentsForGenerators(ExtensionContext context) {
+            return generateArguments(generator).stream();
+        }
+
+        @Override
+        protected long getSeed() {
+            return seed;
+        }
+
+        @Override
+        protected int getCount() {
+            return count;
         }
     }
 

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/CompositeTypeGeneratorArgumentsProviderTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/CompositeTypeGeneratorArgumentsProviderTest.java
@@ -102,6 +102,7 @@ class CompositeTypeGeneratorArgumentsProviderTest {
         provider.accept(annotation);
 
         expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         // when/then
@@ -124,6 +125,7 @@ class CompositeTypeGeneratorArgumentsProviderTest {
         provider.accept(annotation);
 
         expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         // when
@@ -156,6 +158,7 @@ class CompositeTypeGeneratorArgumentsProviderTest {
         provider.accept(annotation);
 
         expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         // when
@@ -188,6 +191,7 @@ class CompositeTypeGeneratorArgumentsProviderTest {
         provider.accept(annotation);
 
         expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         // when
@@ -221,6 +225,7 @@ class CompositeTypeGeneratorArgumentsProviderTest {
         provider.accept(annotation);
 
         expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         // when

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/GenerateArgumentsTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/GenerateArgumentsTest.java
@@ -17,6 +17,7 @@ package de.cuioss.test.generator.junit.parameterized;
 
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.TypedGenerator;
+import de.cuioss.test.generator.internal.RandomContext;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.GeneratorSeed;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +27,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -71,26 +74,30 @@ class GenerateArgumentsTest {
     }
 
     @Test
-    @DisplayName("Should generate arguments with consistent seed")
+    @DisplayName("Should reproduce identical arguments when the seed is reset")
     void shouldGenerateArgumentsWithConsistentSeed() {
-        // Use a fixed generator that always returns the same value
-        var provider = new TestProvider(TEST_SEED, 3);
-        var generator = new FixedStringGenerator("test-value");
+        var provider = new TestProvider(TEST_SEED, 5);
+        // A real, full-range generator: identical output only proves reproducibility if
+        // the seed is actually applied — a fixed generator would pass even when broken.
+        var generator = Generators.integers(Integer.MIN_VALUE, Integer.MAX_VALUE);
 
-        var arguments1 = provider.generateArgumentsPublic(generator);
-        var arguments2 = provider.generateArgumentsPublic(generator);
+        RandomContext.setSeed(TEST_SEED);
+        var first = extractValues(provider.generateArgumentsPublic(generator));
 
-        assertNotNull(arguments1);
-        assertNotNull(arguments2);
-        assertEquals(3, arguments1.size());
-        assertEquals(3, arguments2.size());
+        RandomContext.setSeed(TEST_SEED);
+        var second = extractValues(provider.generateArgumentsPublic(generator));
 
-        // Compare each argument
-        for (int i = 0; i < arguments1.size(); i++) {
-            assertEquals(arguments1.get(i).get()[0], arguments2.get(i).get()[0],
-                    "Arguments should be the same with fixed generator");
-            assertEquals("test-value", arguments1.get(i).get()[0]);
+        assertEquals(first, second, "Re-seeding must reproduce the exact argument sequence");
+        assertTrue(new HashSet<>(first).size() > 1,
+                "A full-range generator must not collapse to a single value");
+    }
+
+    private static List<Object> extractValues(List<Arguments> arguments) {
+        List<Object> values = new ArrayList<>();
+        for (var argument : arguments) {
+            values.add(argument.get()[0]);
         }
+        return values;
     }
 
     @ParameterizedTest(name = "With seed difference={0}, should generate different arguments")
@@ -152,27 +159,6 @@ class GenerateArgumentsTest {
         // Public wrapper for protected method to enable testing
         public List<Arguments> generateArgumentsPublic(TypedGenerator<?> generator) {
             return generateArguments(generator);
-        }
-    }
-
-    /**
-     * A generator that always returns the same fixed string.
-     */
-    private static class FixedStringGenerator implements TypedGenerator<String> {
-        private final String value;
-
-        FixedStringGenerator(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public String next() {
-            return value;
-        }
-
-        @Override
-        public Class<String> getType() {
-            return String.class;
         }
     }
 }

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/TypeGeneratorMethodArgumentsProviderTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/TypeGeneratorMethodArgumentsProviderTest.java
@@ -88,6 +88,7 @@ class TypeGeneratorMethodArgumentsProviderTest {
 
         // Mock the context to return our test class
         expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         expect(context.getRequiredTestClass()).andReturn((Class) TestFactoryClass.class).anyTimes();
         expect(context.getTestInstance()).andReturn(Optional.empty()).anyTimes();
         replay(context);
@@ -116,6 +117,7 @@ class TypeGeneratorMethodArgumentsProviderTest {
 
         // getElement is consulted for @GeneratorSeed resolution; no seed present here
         expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         // when
@@ -140,6 +142,7 @@ class TypeGeneratorMethodArgumentsProviderTest {
         provider.accept(annotation);
 
         expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         // when/then
@@ -156,6 +159,7 @@ class TypeGeneratorMethodArgumentsProviderTest {
         provider.accept(annotation);
 
         expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         expect(context.getRequiredTestClass()).andReturn((Class) TestFactoryClass.class).anyTimes();
         expect(context.getTestInstance()).andReturn(Optional.empty()).anyTimes();
         replay(context);
@@ -174,6 +178,7 @@ class TypeGeneratorMethodArgumentsProviderTest {
         provider.accept(annotation);
 
         expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         // when/then

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/TypeGeneratorMethodArgumentsProviderTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/TypeGeneratorMethodArgumentsProviderTest.java
@@ -17,12 +17,15 @@ package de.cuioss.test.generator.junit.parameterized;
 
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.TypedGenerator;
+import de.cuioss.test.generator.internal.RandomContext;
+import de.cuioss.test.generator.junit.GeneratorSeed;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.platform.commons.JUnitException;
 
+import java.lang.reflect.AnnotatedElement;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -76,7 +79,7 @@ class TypeGeneratorMethodArgumentsProviderTest {
     }
 
     @Test
-    void shouldProvideArgumentsFromTestClassMethod() {
+    void shouldProvideArgumentsFromTestClassMethod() throws Exception {
         // given
         expect(annotation.value()).andReturn("createGenerator").anyTimes();
         expect(annotation.count()).andReturn(3).anyTimes();
@@ -84,6 +87,7 @@ class TypeGeneratorMethodArgumentsProviderTest {
         provider.accept(annotation);
 
         // Mock the context to return our test class
+        expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
         expect(context.getRequiredTestClass()).andReturn((Class) TestFactoryClass.class).anyTimes();
         expect(context.getTestInstance()).andReturn(Optional.empty()).anyTimes();
         replay(context);
@@ -102,7 +106,7 @@ class TypeGeneratorMethodArgumentsProviderTest {
     }
 
     @Test
-    void shouldProvideArgumentsFromExternalClassMethod() {
+    void shouldProvideArgumentsFromExternalClassMethod() throws Exception {
         // given
         String methodReference = TestFactoryClass.class.getName() + "#createGenerator";
         expect(annotation.value()).andReturn(methodReference).anyTimes();
@@ -110,7 +114,9 @@ class TypeGeneratorMethodArgumentsProviderTest {
         replay(annotation);
         provider.accept(annotation);
 
-        replay(context); // Context shouldn't be needed for external class methods
+        // getElement is consulted for @GeneratorSeed resolution; no seed present here
+        expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        replay(context);
 
         // when
         List<Arguments> arguments = provider.provideArguments(null, context)
@@ -133,6 +139,7 @@ class TypeGeneratorMethodArgumentsProviderTest {
         replay(annotation);
         provider.accept(annotation);
 
+        expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         // when/then
@@ -148,6 +155,7 @@ class TypeGeneratorMethodArgumentsProviderTest {
         replay(annotation);
         provider.accept(annotation);
 
+        expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
         expect(context.getRequiredTestClass()).andReturn((Class) TestFactoryClass.class).anyTimes();
         expect(context.getTestInstance()).andReturn(Optional.empty()).anyTimes();
         replay(context);
@@ -165,11 +173,50 @@ class TypeGeneratorMethodArgumentsProviderTest {
         replay(annotation);
         provider.accept(annotation);
 
+        expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
         replay(context);
 
         // when/then
         assertThrows(JUnitException.class, () -> provider.provideArguments(null, context));
         verify(context);
+    }
+
+    @Test
+    void shouldHonorGeneratorSeedAnnotationOnTestMethod() throws Exception {
+        // given a source resolving to an integer generator, 3 values
+        expect(annotation.value()).andReturn("createIntegerGenerator").anyTimes();
+        expect(annotation.count()).andReturn(3).anyTimes();
+        replay(annotation);
+        provider.accept(annotation);
+
+        // and a test method carrying @GeneratorSeed(4242)
+        AnnotatedElement seededMethod = SeedFixture.class.getDeclaredMethod("seeded");
+        expect(context.getElement()).andReturn(Optional.of(seededMethod)).anyTimes();
+        expect(context.getRequiredTestClass()).andReturn((Class) TestFactoryClass.class).anyTimes();
+        expect(context.getTestInstance()).andReturn(Optional.empty()).anyTimes();
+        replay(context);
+
+        // when
+        List<Object> produced = provider.provideArguments(null, context)
+                .map(args -> args.get()[0]).collect(Collectors.toList());
+
+        // then the values match those produced from the annotated seed
+        RandomContext.setSeed(4242L);
+        var generator = TestFactoryClass.createIntegerGenerator();
+        List<Object> baseline = List.of(generator.next(), generator.next(), generator.next());
+        assertEquals(baseline, produced, "@GeneratorSeed must drive @TypeGeneratorMethodSource output");
+        verify(context);
+    }
+
+    /**
+     * Fixture supplying a method annotated with {@link GeneratorSeed}.
+     */
+    static class SeedFixture {
+
+        @GeneratorSeed(4242L)
+        static void seeded() {
+            // marker method for @GeneratorSeed resolution
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes the seed-management and failure-reporting defects from `doc/review-26-07-04.md` (PR 2 of 7).

### Seed handling & reproducibility
- **S-1** — `RandomContext.getConfiguredSeed()` exposes the `de.cuioss.test.generator.seed` property, and `GeneratorControllerExtension.beforeEach` now applies it **directly** as the per-test seed (when no `@GeneratorSeed` is present), so re-running with `-Dde.cuioss.test.generator.seed=<seed>` reproduces a single failing test rather than only a full ordered run.
- **S-2** — malformed property values are caught and logged, falling back to a random seed instead of aborting the whole run with `ExceptionInInitializerError`.
- **S-3** — `lastSeed` is `volatile` and a concrete seed is captured at initialization, so `getLastSeed()` always matches the actual RNG state (never the misleading `0L`).
- **S-4** — `AbstractTypedGeneratorArgumentsProvider` always re-applies an explicitly requested seed, even when it equals the current global seed.
- **S-5** — `TypeGeneratorMethodArgumentsProvider` extends the abstract provider, so `@GeneratorSeed` is honored for `@TypeGeneratorMethodSource`; the duplicated generation loop and dead `getSeed()` are gone.
- **S-6** — the provider no longer rewinds the shared RNG to a previous seed's start (which replayed values); it advances to a fresh seed instead.
- **S-7** — `@GeneratorSeed` is resolved by walking the context outward, covering inherited test methods and `@Nested` classes.
- **S-8 / S-9** — failure augmentation preserves the cause, `expected`/`actual` values and suppressed exceptions, and uses the qualified class name (no spurious `class ` prefix).

### Decision recorded (for E-5, PR 6)
**Replay semantics (S-1):** the `de.cuioss.test.generator.seed` system property is applied as the per-test seed. `about.adoc` (E-5) will be corrected to this property name and behavior in PR 6.

### Tests
- **T-1** — replaced the fixed-generator seed test (which passed even when seed handling was broken) with a real re-seed reproducibility check.
- **T-2** — added coverage for the `@GeneratorSeed` method/class resolution branches and the fallback, plus regressions for malformed property parsing, explicit-seed-equals-lastSeed, `@GeneratorSeed` on `@TypeGeneratorMethodSource`, cause/expected/actual preservation, and `@Nested` inheritance.

## Verification
`./mvnw -Ppre-commit clean install` — green, clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhVybFv6iGrJNXo5Ekg5YA)_