### PR TITLE
fix: parameterized-source provider bugs &amp; diagnostics (J-1..J-10, T-1a)

### DIFF
--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProvider.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProvider.java
@@ -27,7 +27,6 @@ import org.junit.platform.commons.support.AnnotationSupport;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -43,11 +42,6 @@ import static java.util.Objects.requireNonNull;
  * @since 2.0
  */
 public abstract class AbstractTypedGeneratorArgumentsProvider implements ArgumentsProvider {
-
-    /**
-     * Common error message part for method not found exceptions.
-     */
-    protected static final String IN_CLASS = "] in class [";
 
     /**
      * Provides arguments for the parameterized test.
@@ -191,20 +185,5 @@ public abstract class AbstractTypedGeneratorArgumentsProvider implements Argumen
                     "Failed to create TypedGenerator instance for " + generatorClass.getName() +
                             ". Make sure it has a public no-args constructor.", e);
         }
-    }
-
-    /**
-     * Finds a method in the given class that returns a TypedGenerator and takes no parameters.
-     *
-     * @param clazz      the class to search in
-     * @param methodName the method name to find
-     * @return an Optional containing the method, or empty if not found
-     */
-    protected Optional<Method> findMethod(Class<?> clazz, String methodName) {
-        return Arrays.stream(clazz.getDeclaredMethods())
-                .filter(m -> m.getName().equals(methodName))
-                .filter(m -> m.getParameterCount() == 0)
-                .filter(m -> TypedGenerator.class.isAssignableFrom(m.getReturnType()))
-                .findFirst();
     }
 }

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/CompositeTypeGeneratorArgumentsProvider.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/CompositeTypeGeneratorArgumentsProvider.java
@@ -15,7 +15,6 @@
  */
 package de.cuioss.test.generator.junit.parameterized;
 
-import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.TypedGenerator;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
@@ -86,7 +85,7 @@ public class CompositeTypeGeneratorArgumentsProvider extends AbstractTypedGenera
 
         // Add generators from GeneratorType enum values
         for (GeneratorType generatorType : generators) {
-            generatorInstances.add(createGeneratorFromType(generatorType));
+            generatorInstances.add(GeneratorTypeFactory.createGenerator(generatorType));
         }
 
         // Generate values from each generator
@@ -174,14 +173,8 @@ public class CompositeTypeGeneratorArgumentsProvider extends AbstractTypedGenera
      * @throws JUnitException if the lists have different sizes
      */
     private Stream<Arguments> createOneToOnePairs(List<List<Object>> generatedValues) {
-        // Check that all lists have the same size
+        // Every generator produces exactly 'count' values, so all lists share this size.
         int size = generatedValues.getFirst().size();
-        for (List<Object> values : generatedValues) {
-            if (values.size() != size) {
-                throw new JUnitException(
-                        "When cartesianProduct is false, all generators must produce the same number of values");
-            }
-        }
 
         // Create one-to-one pairs
         List<Arguments> arguments = new ArrayList<>();
@@ -194,25 +187,5 @@ public class CompositeTypeGeneratorArgumentsProvider extends AbstractTypedGenera
         }
 
         return arguments.stream();
-    }
-
-    /**
-     * Creates a TypedGenerator from a GeneratorType enum value.
-     *
-     * @param generatorType the generator type
-     * @return a TypedGenerator instance
-     * @throws JUnitException if the generator cannot be created
-     */
-    // cui-rewrite:disable InvalidExceptionUsageRecipe
-    @SuppressWarnings("java:S1452") // This wildcard is because of the TypedGenerator interface. Ok for testing
-    private TypedGenerator<?> createGeneratorFromType(GeneratorType generatorType) {
-        try {
-            // Use reflection to invoke the method on Generators class
-            var methodName = generatorType.getMethodName();
-            var method = Generators.class.getMethod(methodName);
-            return (TypedGenerator<?>) method.invoke(null);
-        } catch (Exception e) {
-            throw new JUnitException("Failed to create generator from type: " + generatorType, e);
-        }
     }
 }

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorMethodResolver.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorMethodResolver.java
@@ -71,18 +71,17 @@ final class GeneratorMethodResolver {
         var method = findMethod(testClass, methodName)
                 .orElseThrow(() -> new JUnitException("Could not find method [" + methodName + IN_CLASS + testClass.getName() + "]"));
 
+        if (!Modifier.isStatic(method.getModifiers()) && testInstance == null) {
+            throw new JUnitException("Cannot invoke instance method [" + methodName + "] without a test instance");
+        }
+
         try {
-            if (Modifier.isStatic(method.getModifiers())) {
-                return (TypedGenerator<?>) JpmsReflectionHelper.invokeMethod(method, null);
-            } else if (testInstance != null) {
-                return (TypedGenerator<?>) JpmsReflectionHelper.invokeMethod(method, testInstance);
-            } else {
-                throw new JUnitException("Cannot invoke instance method [" + methodName + "] without a test instance");
-            }
+            var target = Modifier.isStatic(method.getModifiers()) ? null : testInstance;
+            return (TypedGenerator<?>) JpmsReflectionHelper.invokeMethod(method, target);
+        } catch (JUnitException e) {
+            // Precise diagnostics (JPMS access, etc.) must not be buried by a generic wrapper
+            throw e;
         } catch (Exception e) {
-            if (e instanceof JUnitException jpmsEx && JpmsReflectionHelper.isJpmsAccessException(jpmsEx)) {
-                throw jpmsEx;
-            }
             throw new JUnitException("Failed to invoke method [" + methodName + "]", e);
         }
     }
@@ -117,10 +116,10 @@ final class GeneratorMethodResolver {
             return (TypedGenerator<?>) JpmsReflectionHelper.invokeMethod(method, null);
         } catch (ClassNotFoundException e) {
             throw new JUnitException("Could not find class [" + className + "]", e);
+        } catch (JUnitException e) {
+            // Precise diagnostics (not-found, must-be-static, JPMS access) must surface unwrapped
+            throw e;
         } catch (Exception e) {
-            if (e instanceof JUnitException jpmsEx && JpmsReflectionHelper.isJpmsAccessException(jpmsEx)) {
-                throw jpmsEx;
-            }
             throw new JUnitException("Failed to invoke method [" + localMethodName + IN_CLASS + className + "]", e);
         }
     }

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorType.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorType.java
@@ -49,8 +49,14 @@ import java.util.TimeZone;
 import java.util.UUID;
 
 /**
- * Enum representing all available generator types from the {@link de.cuioss.test.generator.Generators} class.
- * Used with {@link GeneratorsSource} to specify which generator method to use.
+ * Enum of the generator types that can be referenced from {@link GeneratorsSource} and
+ * {@link CompositeTypeGeneratorSource}.
+ * <p>
+ * This covers the subset of {@link de.cuioss.test.generator.Generators} factory methods and
+ * domain generators that are expressible through the factory-method / factory-class mechanism.
+ * Generators that need caller-supplied values (such as {@code fixedValues}) or that are
+ * enum-based (such as {@code OrganizationNameGenerator}, {@code TitleGenerator} and
+ * {@code NameGenerators}) are intentionally not represented here.
  *
  * @author Oliver Wolff
  * @since 2.3
@@ -178,9 +184,6 @@ public enum GeneratorType {
 
     /** Generates random URL objects with various protocols, hosts, and paths. */
     URLS("urls", Generators.class, URL.class, GeneratorParameterType.PARAMETERLESS),
-
-    /** Generates values from a fixed set of predefined values. */
-    FIXED_VALUES("fixedValues", Generators.class, Object.class, GeneratorParameterType.PARAMETERLESS),
 
     // Domain-specific generators
     /** Generates random placeholder text (lorem ipsum style) for testing text-heavy components. */

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorTypeFactory.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorTypeFactory.java
@@ -107,17 +107,22 @@ final class GeneratorTypeFactory {
 
     private static TypedGenerator<?> createRangeGenerator(GeneratorType type, String methodName, String low, String high) {
         var returnType = type.getReturnType();
-        if (Integer.class.equals(returnType)) {
-            return invoke(findMethod(methodName, int.class, int.class), Integer.parseInt(low), Integer.parseInt(high));
-        }
-        if (Long.class.equals(returnType)) {
-            return invoke(findMethod(methodName, long.class, long.class), Long.parseLong(low), Long.parseLong(high));
-        }
-        if (Double.class.equals(returnType)) {
-            return invoke(findMethod(methodName, double.class, double.class), Double.parseDouble(low), Double.parseDouble(high));
-        }
-        if (Float.class.equals(returnType)) {
-            return invoke(findMethod(methodName, float.class, float.class), Float.parseFloat(low), Float.parseFloat(high));
+        try {
+            if (Integer.class.equals(returnType)) {
+                return invoke(findMethod(methodName, int.class, int.class), Integer.parseInt(low), Integer.parseInt(high));
+            }
+            if (Long.class.equals(returnType)) {
+                return invoke(findMethod(methodName, long.class, long.class), Long.parseLong(low), Long.parseLong(high));
+            }
+            if (Double.class.equals(returnType)) {
+                return invoke(findMethod(methodName, double.class, double.class), Double.parseDouble(low), Double.parseDouble(high));
+            }
+            if (Float.class.equals(returnType)) {
+                return invoke(findMethod(methodName, float.class, float.class), Float.parseFloat(low), Float.parseFloat(high));
+            }
+        } catch (NumberFormatException e) {
+            throw new JUnitException("Invalid range for generator '" + methodName + "' (return type "
+                    + returnType.getSimpleName() + "): low='" + low + "', high='" + high + "'", e);
         }
         throw new JUnitException("Range generator for return type '" + returnType.getSimpleName() + "' is not supported");
     }

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorTypeFactory.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorTypeFactory.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.generator.junit.parameterized;
+
+import de.cuioss.test.generator.Generators;
+import de.cuioss.test.generator.TypedGenerator;
+import org.junit.platform.commons.JUnitException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Shared creation of {@link TypedGenerator} instances from {@link GeneratorType} constants.
+ * <p>
+ * Used by both {@link GeneratorsSourceArgumentsProvider} (which supplies bounds/range from the
+ * annotation) and {@link CompositeTypeGeneratorArgumentsProvider} (which has no parameters and
+ * therefore relies on the default factory methods). Centralizing the dispatch keeps the two
+ * providers consistent — in particular, domain generators (whose {@code methodName} is
+ * {@code null}) are instantiated from their factory class in both cases.
+ *
+ * @author Oliver Wolff
+ */
+final class GeneratorTypeFactory {
+
+    private GeneratorTypeFactory() {
+        // utility class
+    }
+
+    /**
+     * Creates a generator honoring the parameters supplied via {@code @GeneratorsSource}: bounds
+     * ({@code minSize}/{@code maxSize}) for {@code NEEDS_BOUNDS} types and a range
+     * ({@code low}/{@code high}) for {@code NEEDS_RANGE} types.
+     *
+     * @param type    the generator type, must not be {@code null}
+     * @param minSize lower bound for size-parameterized generators
+     * @param maxSize upper bound for size-parameterized generators
+     * @param low     lower bound (parsed) for range-parameterized generators
+     * @param high    upper bound (parsed) for range-parameterized generators
+     * @return a new {@link TypedGenerator}
+     * @throws JUnitException if the generator cannot be created
+     */
+    static TypedGenerator<?> createGenerator(GeneratorType type, int minSize, int maxSize, String low, String high) {
+        requireNonNull(type, "Generator type must not be null");
+        if (isDomainSpecific(type)) {
+            return createDomainGenerator(type);
+        }
+        var methodName = requireMethodName(type);
+        return switch (type.getParameterType()) {
+            case NEEDS_BOUNDS -> invoke(findMethod(methodName, int.class, int.class), minSize, maxSize);
+            case NEEDS_RANGE -> createRangeGenerator(type, methodName, low, high);
+            case PARAMETERLESS -> invoke(findMethod(methodName));
+        };
+    }
+
+    /**
+     * Creates a generator using default parameters, for callers that cannot supply bounds or a
+     * range (i.e. {@code @CompositeTypeGeneratorSource}). Standard types are created via their
+     * parameterless factory method; domain types via their factory class.
+     *
+     * @param type the generator type, must not be {@code null}
+     * @return a new {@link TypedGenerator}
+     * @throws JUnitException if the generator cannot be created
+     */
+    static TypedGenerator<?> createGenerator(GeneratorType type) {
+        requireNonNull(type, "Generator type must not be null");
+        if (isDomainSpecific(type)) {
+            return createDomainGenerator(type);
+        }
+        return invoke(findMethod(requireMethodName(type)));
+    }
+
+    private static boolean isDomainSpecific(GeneratorType type) {
+        return type.getMethodName() == null
+                && type.getFactoryClass() != null
+                && TypedGenerator.class.isAssignableFrom(type.getFactoryClass());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static TypedGenerator<?> createDomainGenerator(GeneratorType type) {
+        return JpmsReflectionHelper.newGeneratorInstance(
+                (Class<? extends TypedGenerator<?>>) type.getFactoryClass());
+    }
+
+    private static String requireMethodName(GeneratorType type) {
+        var methodName = type.getMethodName();
+        if (methodName == null) {
+            throw new JUnitException(
+                    "Generator type '" + type + "' has no factory method and its factory class is not a TypedGenerator");
+        }
+        return methodName;
+    }
+
+    private static TypedGenerator<?> createRangeGenerator(GeneratorType type, String methodName, String low, String high) {
+        var returnType = type.getReturnType();
+        if (Integer.class.equals(returnType)) {
+            return invoke(findMethod(methodName, int.class, int.class), Integer.parseInt(low), Integer.parseInt(high));
+        }
+        if (Long.class.equals(returnType)) {
+            return invoke(findMethod(methodName, long.class, long.class), Long.parseLong(low), Long.parseLong(high));
+        }
+        if (Double.class.equals(returnType)) {
+            return invoke(findMethod(methodName, double.class, double.class), Double.parseDouble(low), Double.parseDouble(high));
+        }
+        if (Float.class.equals(returnType)) {
+            return invoke(findMethod(methodName, float.class, float.class), Float.parseFloat(low), Float.parseFloat(high));
+        }
+        throw new JUnitException("Range generator for return type '" + returnType.getSimpleName() + "' is not supported");
+    }
+
+    private static Method findMethod(String methodName, Class<?>... parameterTypes) {
+        try {
+            return Generators.class.getMethod(methodName, parameterTypes);
+        } catch (NoSuchMethodException e) {
+            throw new JUnitException("Could not find static generator method '" + methodName
+                    + "' in " + Generators.class.getName() + " with the required parameter types", e);
+        }
+    }
+
+    // cui-rewrite:disable InvalidExceptionUsageRecipe
+    private static TypedGenerator<?> invoke(Method method, Object... args) {
+        try {
+            return (TypedGenerator<?>) method.invoke(null, args);
+        } catch (InvocationTargetException e) {
+            var cause = e.getTargetException();
+            throw new JUnitException("Generator method '" + method.getName() + "' failed: " + cause.getMessage(), cause);
+        } catch (IllegalAccessException e) {
+            throw new JUnitException("Cannot access generator method '" + method.getName() + "'", e);
+        }
+    }
+}

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorsSourceArgumentsProvider.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorsSourceArgumentsProvider.java
@@ -20,13 +20,8 @@ import de.cuioss.test.generator.TypedGenerator;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.support.AnnotationConsumer;
-import org.junit.platform.commons.JUnitException;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.stream.Stream;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of {@link org.junit.jupiter.params.provider.ArgumentsProvider} that provides arguments from a
@@ -73,15 +68,7 @@ public class GeneratorsSourceArgumentsProvider extends AbstractTypedGeneratorArg
 
     @Override
     protected Stream<? extends Arguments> provideArgumentsForGenerators(ExtensionContext context) {
-        // Create generator instance using factory
-        TypedGenerator<?> generator;
-        try {
-            generator = createGeneratorFromFactory();
-        } catch (InvocationTargetException | IllegalAccessException e) {
-            throw new IllegalStateException(e);
-        }
-
-        // Generate values
+        var generator = GeneratorTypeFactory.createGenerator(generatorType, minSize, maxSize, low, high);
         return generateArguments(generator).stream();
     }
 
@@ -93,130 +80,5 @@ public class GeneratorsSourceArgumentsProvider extends AbstractTypedGeneratorArg
     @Override
     protected int getCount() {
         return count;
-    }
-
-    /**
-     * Creates a TypedGenerator instance based on the generator type.
-     *
-     * @return a TypedGenerator instance
-     * @throws JUnitException if the generator cannot be created
-     */
-    private TypedGenerator<?> createGeneratorFromFactory() throws InvocationTargetException, IllegalAccessException {
-        requireNonNull(generatorType, "Generator type must not be null");
-
-        // Check if this is a domain-specific generator (factory class is the generator class itself)
-        if (isDomainSpecificGenerator()) {
-            return createDomainSpecificGenerator();
-        }
-
-        // Otherwise, it's a standard generator from the Generators class
-        String methodName = generatorType.getMethodName();
-        requireNonNull(methodName, "Generator method name must not be null");
-
-        return switch (generatorType.getParameterType()) {
-            case NEEDS_BOUNDS -> createStringGenerator();
-            case NEEDS_RANGE -> createNumberGenerator();
-            case PARAMETERLESS -> createParameterlessGenerator();
-        };
-    }
-
-    /**
-     * Checks if the generator type is a domain-specific generator.
-     *
-     * @return true if it's a domain-specific generator
-     */
-    private boolean isDomainSpecificGenerator() {
-        return generatorType.getMethodName() == null &&
-                generatorType.getFactoryClass() != null &&
-                TypedGenerator.class.isAssignableFrom(generatorType.getFactoryClass());
-    }
-
-    /**
-     * Creates a domain-specific generator by instantiating the generator class.
-     *
-     * @return a TypedGenerator instance
-     */
-    @SuppressWarnings("unchecked")
-    private TypedGenerator<?> createDomainSpecificGenerator() {
-        Class<?> generatorClass = generatorType.getFactoryClass();
-        return JpmsReflectionHelper.newGeneratorInstance((Class<? extends TypedGenerator<?>>) generatorClass);
-    }
-
-    /**
-     * Creates a string-based generator using the minSize and maxSize parameters.
-     *
-     * @return a TypedGenerator for strings
-     */
-    private TypedGenerator<?> createStringGenerator() throws InvocationTargetException, IllegalAccessException {
-        Method method = findMethodWithParameters(generatorType.getMethodName(), int.class, int.class);
-        return (TypedGenerator<?>) method.invoke(null, minSize, maxSize);
-    }
-
-    /**
-     * Creates a number-based generator using the low and high parameters.
-     *
-     * @return a TypedGenerator for numbers
-     */
-    private TypedGenerator<?> createNumberGenerator() throws InvocationTargetException, IllegalAccessException {
-        // Determine the parameter types based on the generator return type
-        Class<?>[] paramTypes;
-        Object[] params;
-
-        Class<?> returnType = generatorType.getReturnType();
-
-        if (Integer.class.equals(returnType)) {
-            paramTypes = new Class<?>[]{int.class, int.class};
-            params = new Object[]{Integer.parseInt(low), Integer.parseInt(high)};
-        } else if (Long.class.equals(returnType)) {
-            paramTypes = new Class<?>[]{long.class, long.class};
-            params = new Object[]{Long.parseLong(low), Long.parseLong(high)};
-        } else if (Double.class.equals(returnType)) {
-            paramTypes = new Class<?>[]{double.class, double.class};
-            params = new Object[]{Double.parseDouble(low), Double.parseDouble(high)};
-        } else if (Float.class.equals(returnType)) {
-            paramTypes = new Class<?>[]{float.class, float.class};
-            params = new Object[]{Float.parseFloat(low), Float.parseFloat(high)};
-        } else if (Short.class.equals(returnType)) {
-            paramTypes = new Class<?>[]{short.class, short.class};
-            params = new Object[]{Short.parseShort(low), Short.parseShort(high)};
-        } else if (Byte.class.equals(returnType)) {
-            paramTypes = new Class<?>[]{byte.class, byte.class};
-            params = new Object[]{Byte.parseByte(low), Byte.parseByte(high)};
-        } else {
-            throw new UnsupportedOperationException(
-                    "Number generator for type '" + returnType.getSimpleName() + "' is not supported.");
-        }
-
-        Method method = findMethodWithParameters(generatorType.getMethodName(), paramTypes);
-        return (TypedGenerator<?>) method.invoke(null, params);
-    }
-
-    /**
-     * Creates a generator that doesn't require parameters.
-     *
-     * @return a TypedGenerator
-     */
-    private TypedGenerator<?> createParameterlessGenerator() throws InvocationTargetException, IllegalAccessException {
-        Method method = findMethodWithParameters(generatorType.getMethodName());
-        return (TypedGenerator<?>) method.invoke(null);
-    }
-
-
-    /**
-     * Finds a generator method in the Generators class with the specified parameter types.
-     *
-     * @param methodName     the name of the method to find
-     * @param parameterTypes the parameter types the method should accept
-     * @return the generator method
-     * @throws JUnitException if the method cannot be found
-     */
-    private Method findMethodWithParameters(String methodName, Class<?>... parameterTypes) {
-        try {
-            return Generators.class.getMethod(methodName, parameterTypes);
-        } catch (NoSuchMethodException e) {
-            throw new JUnitException(
-                    "Could not find static generator method '" + methodName +
-                            "' in Generators class with the specified parameter types", e);
-        }
     }
 }

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/TypeGeneratorFactoryArgumentsProvider.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/TypeGeneratorFactoryArgumentsProvider.java
@@ -119,34 +119,24 @@ public class TypeGeneratorFactoryArgumentsProvider extends AbstractTypedGenerato
      * @throws JUnitException if the method cannot be found
      */
     private Method findFactoryMethod() {
-        // Look for a method with the exact parameter count
+        // The provided parameters are always Strings, so only all-String-parameter overloads are
+        // viable candidates. Filtering up front removes the nondeterministic getFirst() fallback.
         List<Method> candidateMethods = Arrays.stream(factoryClass.getMethods())
                 .filter(m -> m.getName().equals(factoryMethod))
                 .filter(m -> Modifier.isStatic(m.getModifiers()))
                 .filter(m -> m.getParameterCount() == methodParameters.length)
                 .filter(m -> TypedGenerator.class.isAssignableFrom(m.getReturnType()))
+                .filter(m -> Arrays.stream(m.getParameterTypes()).allMatch(p -> p == String.class))
                 .toList();
 
         if (candidateMethods.isEmpty()) {
             throw new JUnitException(
                     "Could not find static factory method '" + factoryMethod +
                             "' in class '" + factoryClass.getName() +
-                            "' with " + methodParameters.length + " parameters that returns TypedGenerator");
+                            "' with " + methodParameters.length + " String parameter(s) that returns TypedGenerator");
         }
 
-        if (candidateMethods.size() > 1) {
-            // If multiple methods match, try to find one that accepts String parameters
-            var stringParamMethods = candidateMethods.stream()
-                    .filter(m -> Arrays.stream(m.getParameterTypes())
-                            .allMatch(p -> p == String.class))
-                    .toList();
-
-            if (stringParamMethods.size() == 1) {
-                return stringParamMethods.getFirst();
-            }
-        }
-
-        // If we have exactly one candidate or couldn't narrow down further, use the first one
+        // Two same-arity, all-String overloads are impossible in Java, so this is unambiguous.
         return candidateMethods.getFirst();
     }
 }

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProviderTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/AbstractTypedGeneratorArgumentsProviderTest.java
@@ -25,12 +25,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.JUnitException;
 
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -60,26 +58,6 @@ class AbstractTypedGeneratorArgumentsProviderTest {
     void shouldThrowExceptionForInvalidGenerator() {
         var provider = new TestProvider(TEST_SEED, 1);
         assertThrows(JUnitException.class, () -> provider.createGeneratorInstancePublic(InvalidGenerator.class));
-    }
-
-    static Stream<Arguments> methodTestCases() {
-        return Stream.of(
-                // methodName, expectedFound
-                Arguments.of("createGenerator", true),
-                Arguments.of("nonExistentMethod", false),
-                Arguments.of("wrongReturnType", false)
-        );
-    }
-
-    @ParameterizedTest(name = "Finding method {0} should return {1}")
-    @MethodSource("methodTestCases")
-    @DisplayName("Should correctly find or not find methods")
-    void shouldFindMethodCorrectly(String methodName, boolean expectedFound) {
-        var provider = new TestProvider(TEST_SEED, 1);
-        var methodOpt = provider.findMethodPublic(TestClass.class, methodName);
-
-        assertNotNull(methodOpt);
-        assertEquals(expectedFound, methodOpt.isPresent());
     }
 
     @Test
@@ -206,10 +184,6 @@ class AbstractTypedGeneratorArgumentsProviderTest {
 
         public TypedGenerator<?> createGeneratorInstancePublic(Class<? extends TypedGenerator<?>> generatorClass) {
             return createGeneratorInstance(generatorClass);
-        }
-
-        public Optional<Method> findMethodPublic(Class<?> clazz, String methodName) {
-            return findMethod(clazz, methodName);
         }
 
         public List<Arguments> generateArgumentsPublic(TypedGenerator<?> generator) {

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/CompositeTypeGeneratorArgumentsProviderTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/CompositeTypeGeneratorArgumentsProviderTest.java
@@ -242,6 +242,36 @@ class CompositeTypeGeneratorArgumentsProviderTest {
         verify(context);
     }
 
+    @Test
+    void shouldProvideArgumentsFromDomainGeneratorType() throws Exception {
+        // Regression for J-1: DOMAIN_* types (methodName == null) previously NPE'd here.
+        @SuppressWarnings("unchecked") Class<? extends TypedGenerator<?>>[] generatorClasses = new Class[0];
+
+        expect(annotation.generatorClasses()).andReturn(generatorClasses).anyTimes();
+        expect(annotation.generatorMethods()).andReturn(new String[0]).anyTimes();
+        expect(annotation.generators()).andReturn(new GeneratorType[]{GeneratorType.DOMAIN_CITY}).anyTimes();
+        expect(annotation.count()).andReturn(3).anyTimes();
+        expect(annotation.cartesianProduct()).andReturn(false).anyTimes();
+        replay(annotation);
+        provider.accept(annotation);
+
+        expect(context.getElement()).andReturn(Optional.empty()).anyTimes();
+        expect(context.getParent()).andReturn(Optional.empty()).anyTimes();
+        replay(context);
+
+        // when
+        List<Arguments> arguments = provider.provideArguments(null, context)
+                .collect(Collectors.toList());
+
+        // then
+        assertEquals(3, arguments.size());
+        for (Arguments args : arguments) {
+            assertEquals(1, args.get().length);
+            assertInstanceOf(String.class, args.get()[0]);
+        }
+        verify(context);
+    }
+
     /**
      * Test generator class that implements TypedGenerator.
      */

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/GeneratorMethodResolverTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/GeneratorMethodResolverTest.java
@@ -50,8 +50,8 @@ class GeneratorMethodResolverTest {
         return Stream.of(
                 arguments("invalid#format#method", "Could not find class [invalid]"),
                 arguments("com.nonexistent.Class#method", "Could not find class [com.nonexistent.Class]"),
-                arguments(TestFactoryClass.class.getName() + "#nonExistentMethod", "Failed to invoke method [nonExistentMethod] in class [" + TestFactoryClass.class.getName() + "]"),
-                arguments(TestFactoryClass.class.getName() + "#createDoubleGenerator", "Failed to invoke method [createDoubleGenerator] in class [" + TestFactoryClass.class.getName() + "]")
+                arguments(TestFactoryClass.class.getName() + "#nonExistentMethod", "Could not find method [nonExistentMethod] in class [" + TestFactoryClass.class.getName() + "]"),
+                arguments(TestFactoryClass.class.getName() + "#createDoubleGenerator", "Method [createDoubleGenerator] in external class [" + TestFactoryClass.class.getName() + "] must be static")
         );
     }
 
@@ -106,7 +106,7 @@ class GeneratorMethodResolverTest {
 
     static Stream<Arguments> invalidMethodScenarios() {
         return Stream.of(
-                arguments("createDoubleGenerator", false, "Failed to invoke method [createDoubleGenerator]"),
+                arguments("createDoubleGenerator", false, "Cannot invoke instance method [createDoubleGenerator] without a test instance"),
                 arguments(null, true, null), // Should throw NullPointerException
                 arguments("", false, "Method name must not be blank")
         );

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/GeneratorTypeFactoryTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/GeneratorTypeFactoryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.generator.junit.parameterized;
+
+import de.cuioss.test.generator.junit.EnableGeneratorController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@EnableGeneratorController
+@DisplayName("GeneratorTypeFactory should")
+class GeneratorTypeFactoryTest {
+
+    @ParameterizedTest
+    @EnumSource(GeneratorType.class)
+    @DisplayName("create a working generator for every GeneratorType via the default path")
+    void shouldCreateEveryGeneratorTypeWithDefaults(GeneratorType type) {
+        // Regression for J-1 (domain types) and J-2 (no unusable FIXED_VALUES constant):
+        // every constant must resolve to a usable generator through the shared default path.
+        var generator = GeneratorTypeFactory.createGenerator(type);
+        assertNotNull(generator, () -> "No generator created for " + type);
+        assertNotNull(generator.next(), () -> "Null value produced for " + type);
+    }
+
+    @Test
+    @DisplayName("instantiate domain generators from their factory class")
+    void shouldCreateDomainGeneratorFromFactoryClass() {
+        var generator = GeneratorTypeFactory.createGenerator(GeneratorType.DOMAIN_CITY);
+        assertNotNull(generator.next());
+        assertEquals(String.class, generator.getType());
+    }
+
+    @Test
+    @DisplayName("honor explicit bounds for NEEDS_BOUNDS types")
+    void shouldHonorExplicitBounds() {
+        var generator = GeneratorTypeFactory.createGenerator(GeneratorType.STRINGS, 5, 5, "0", "0");
+        var value = (String) generator.next();
+        assertEquals(5, value.length());
+    }
+
+    @Test
+    @DisplayName("honor explicit range for NEEDS_RANGE types")
+    void shouldHonorExplicitRange() {
+        var generator = GeneratorTypeFactory.createGenerator(GeneratorType.INTEGERS, 0, 0, "7", "7");
+        assertEquals(7, generator.next());
+    }
+}

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/GeneratorTypeFactoryTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/GeneratorTypeFactoryTest.java
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.platform.commons.JUnitException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnableGeneratorController
 @DisplayName("GeneratorTypeFactory should")
@@ -60,5 +60,13 @@ class GeneratorTypeFactoryTest {
     void shouldHonorExplicitRange() {
         var generator = GeneratorTypeFactory.createGenerator(GeneratorType.INTEGERS, 0, 0, "7", "7");
         assertEquals(7, generator.next());
+    }
+
+    @Test
+    @DisplayName("wrap malformed range bounds in a descriptive JUnitException")
+    void shouldRejectMalformedRange() {
+        var exception = assertThrows(JUnitException.class,
+                () -> GeneratorTypeFactory.createGenerator(GeneratorType.INTEGERS, 0, 0, "not-a-number", "10"));
+        assertTrue(exception.getMessage().contains("Invalid range"), exception.getMessage());
     }
 }

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/TypeGeneratorFactoryArgumentsProviderTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/TypeGeneratorFactoryArgumentsProviderTest.java
@@ -168,26 +168,20 @@ class TypeGeneratorFactoryArgumentsProviderTest {
     }
 
     @Test
-    @DisplayName("Should handle multiple matching methods without string parameters")
-    void shouldHandleMultipleMatchingMethodsWithoutStringParameters() throws Exception {
+    @DisplayName("Should reject overloads whose parameters are not all Strings")
+    void shouldRejectMethodsWithoutStringParameters() throws Exception {
         var provider = new TestProvider();
         setPrivateField(provider, "factoryClass", TestFactoryClass.class);
         setPrivateField(provider, "factoryMethod", "ambiguousMethod");
         setPrivateField(provider, "methodParameters", new String[]{"test"});
 
-        TypedGenerator<?> generator;
-        try {
-            generator = invokeCreateGeneratorFromFactory(provider);
-        } catch (InvocationTargetException e) {
-            if (e.getTargetException() instanceof Exception) {
-                throw (Exception) e.getTargetException();
-            }
-            throw new RuntimeException(e.getTargetException());
-        }
-
-        assertNotNull(generator);
-        // Verify that a valid generator is returned
-        assertInstanceOf(TypedGenerator.class, generator);
+        // ambiguousMethod only has Object/Comparable overloads; the provided parameters are always
+        // Strings, so no viable candidate exists and a clear diagnostic must be raised rather than
+        // a nondeterministic getFirst() pick.
+        var exception = assertThrows(InvocationTargetException.class,
+                () -> invokeCreateGeneratorFromFactory(provider));
+        var cause = assertInstanceOf(JUnitException.class, exception.getTargetException());
+        assertTrue(cause.getMessage().contains("String parameter(s)"), cause.getMessage());
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes the parameterized-source provider defects from `doc/review-26-07-04.md` (PR 3 of 7).

- **J-1 / J-3** — extracted a shared `GeneratorTypeFactory` used by both `@GeneratorsSource` and `@CompositeTypeGeneratorSource`. Domain generators (whose `methodName` is `null`) are now instantiated from their factory class in the composite provider too, so **every `DOMAIN_*` type works with `@CompositeTypeGeneratorSource`** instead of throwing an NPE.
- **J-2** — removed `GeneratorType.FIXED_VALUES`; it mapped to a non-existent zero-arg `Generators.fixedValues()` and could never be instantiated. ⚠️ **API removal** (see release notes) — there is no annotation mechanism to pass the fixed values.
- **J-4** — `GeneratorMethodResolver` rethrows `JUnitException`, so precise diagnostics (`Cannot invoke instance method …`, `… must be static`, `Could not find method …`) surface instead of being buried under a generic wrapper.
- **J-5** — reflection failures surface as `JUnitException` with the generator name and the unwrapped target exception, replacing the message-less `IllegalStateException`.
- **J-6** — `TypeGeneratorFactoryArgumentsProvider` filters to all-String-parameter overloads up front and raises a clear no-match diagnostic, removing the nondeterministic `getFirst()` fallback.
- **J-7** — deleted the dead `IN_CLASS` constant and duplicate `findMethod` from the abstract provider (already covered by `GeneratorMethodResolver`).
- **J-8 / J-9** — removed the dead size-mismatch check in `createOneToOnePairs` and the unreachable `Short`/`Byte` range branches.
- **J-10** — softened the `GeneratorType` Javadoc to describe the supported subset.

## Tests
- Every `GeneratorType` is exercised through `GeneratorTypeFactory` and a `DOMAIN_*` type through `@CompositeTypeGeneratorSource` (**J-1, J-2, T-1a**).
- All-String overload rejection (**J-6**) and the improved resolver diagnostics (**J-4**).

## Release notes
- **Removed** `GeneratorType.FIXED_VALUES` (was unusable).

## Verification
`./mvnw -Ppre-commit clean install` — green, clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhVybFv6iGrJNXo5Ekg5YA)_