### PR TITLE
fix: core generator implementations (C-1..C-12)

### DIFF
--- a/src/main/java/de/cuioss/test/generator/Generators.java
+++ b/src/main/java/de/cuioss/test/generator/Generators.java
@@ -103,6 +103,14 @@ import static java.util.Objects.requireNonNull;
 @UtilityClass
 public class Generators {
 
+    /** Cached list of all available {@link TimeZone}s; rebuilding it per call is expensive. */
+    private static final List<TimeZone> TIME_ZONES =
+            Arrays.stream(TimeZone.getAvailableIDs()).map(TimeZone::getTimeZone).toList();
+
+    /** Cached list of all available {@link ZoneId}s; rebuilding it per call is expensive. */
+    private static final List<ZoneId> ZONE_IDS =
+            ZoneId.getAvailableZoneIds().stream().map(ZoneId::of).toList();
+
     /**
      * Factory method for creating a generator for a possible given enum.
      *
@@ -145,6 +153,9 @@ public class Generators {
      */
     public static <T extends Enum<T>> TypedGenerator<T> enumValues(final Class<T> type) {
         requireNonNull(type);
+        if (!type.isEnum()) {
+            throw new IllegalArgumentException("type must represent an enum, given: " + type.getName());
+        }
         return new FixedValuesGenerator<>(type, Arrays.asList(type.getEnumConstants()));
     }
 
@@ -222,13 +233,13 @@ public class Generators {
 
     /**
      * Factory method for creating a {@link TypedGenerator} for sensible / simple
-     * non empty letter Strings. The mininmal size is 3, the maximal size between 3
-     * and 256 characters
+     * non empty letter Strings. Each generated value draws its own length in the
+     * inclusive range 3 to 256 characters.
      *
      * @return a {@link TypedGenerator} for Strings
      */
     public static TypedGenerator<String> letterStrings() {
-        return letterStrings(3, integers(3, 256).next());
+        return letterStrings(3, 256);
     }
 
     /**
@@ -289,7 +300,7 @@ public class Generators {
      * @return a {@link TypedGenerator} for the given values
      */
     public static <T> TypedGenerator<T> fixedValues(final Iterable<T> values) {
-        return fixedValues(determineSupertypeFromIterable(values), values);
+        return fixedValues(determineTypeFromFirstElement(values), values);
     }
 
     /* Combined generators */
@@ -583,11 +594,7 @@ public class Generators {
      * @return a {@link TypedGenerator} for {@link TimeZone}
      */
     public static TypedGenerator<TimeZone> timeZones() {
-        final List<TimeZone> timezones = new ArrayList<>();
-        for (final String id : TimeZone.getAvailableIDs()) {
-            timezones.add(TimeZone.getTimeZone(id));
-        }
-        return fixedValues(TimeZone.class, timezones);
+        return fixedValues(TimeZone.class, TIME_ZONES);
     }
 
     /**
@@ -596,7 +603,7 @@ public class Generators {
      * @return a {@link TypedGenerator} for {@link ZoneId}
      */
     public static TypedGenerator<ZoneId> zoneIds() {
-        return fixedValues(ZoneId.class, ZoneId.getAvailableZoneIds().stream().map(ZoneId::of).toList());
+        return fixedValues(ZoneId.class, ZONE_IDS);
     }
 
     /**
@@ -707,19 +714,25 @@ public class Generators {
     }
 
     /**
-     * Helper method that determines the actual type of a given {@link Iterable} by
-     * peeking into it. <em>For testing only, should never be used in productive
-     * code</em>
+     * Determines the element type by peeking at the first element of the given
+     * {@link Iterable} and returning its concrete runtime class. Note that for
+     * heterogeneous input this is the type of the first element only, not a common
+     * supertype of all elements.
      *
-     * @param iterable must not be null nor empty, the iterator must be reentrant.
-     * @return The Class of the given {@link Iterable}.
+     * @param iterable must not be null nor empty, and its first element must not be null;
+     *                 the iterator must be reentrant.
+     * @return the concrete runtime {@link Class} of the first element.
+     * @throws IllegalArgumentException if the iterable is empty
+     * @throws NullPointerException     if the iterable or its first element is null
      */
     @SuppressWarnings("unchecked")
-    private static <T> Class<T> determineSupertypeFromIterable(final Iterable<T> iterable) {
+    private static <T> Class<T> determineTypeFromFirstElement(final Iterable<T> iterable) {
         requireNonNull(iterable, "iterable must not be null");
         final var iterator = iterable.iterator();
         if (iterator.hasNext()) {
-            return (Class<T>) iterator.next().getClass();
+            final T first = iterator.next();
+            requireNonNull(first, "The first element must not be null to determine the type");
+            return (Class<T>) first.getClass();
         }
         throw new IllegalArgumentException("Must contain at least a single element");
     }

--- a/src/main/java/de/cuioss/test/generator/impl/DoubleGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/DoubleGenerator.java
@@ -22,8 +22,9 @@ import lombok.Getter;
 /**
  * Generates random {@link Double} values within a configurable range.
  * <p>
- * Note: The default range uses {@link Double#MIN_VALUE} (smallest positive value, ~4.9E-324)
- * to {@link Double#MAX_VALUE}. For negative doubles, use the two-argument constructor.
+ * The default range spans the full finite double range,
+ * {@code -Double.MAX_VALUE} to {@link Double#MAX_VALUE}, so negative values and zero are
+ * produced. Use the two-argument constructor for a narrower range.
  * </p>
  *
  * @author Oliver Wolff
@@ -35,19 +36,23 @@ public class DoubleGenerator implements TypedGenerator<Double> {
     private final double max;
 
     /**
-     * Creates a generator for the full double range.
+     * Creates a generator for the full finite double range.
      */
     public DoubleGenerator() {
-        this(Double.MIN_VALUE, Double.MAX_VALUE);
+        this(-Double.MAX_VALUE, Double.MAX_VALUE);
     }
 
     /**
      * Creates a generator for doubles in the range [min, max].
      *
-     * @param min lower bound (inclusive)
-     * @param max upper bound (inclusive)
+     * @param min lower bound (inclusive), must be finite
+     * @param max upper bound (inclusive), must be finite
+     * @throws IllegalArgumentException if a bound is not finite or {@code max < min}
      */
     public DoubleGenerator(double min, double max) {
+        if (!Double.isFinite(min) || !Double.isFinite(max)) {
+            throw new IllegalArgumentException("min and max must be finite, given: [" + min + ", " + max + "]");
+        }
         if (max < min) {
             throw new IllegalArgumentException("max must be >= min");
         }
@@ -61,11 +66,15 @@ public class DoubleGenerator implements TypedGenerator<Double> {
             return min;
         }
         double bound = Math.nextUp(max);
-        if (Double.isInfinite(bound)) {
-            // max is Double.MAX_VALUE; fall back to scaled nextDouble
-            return RandomContext.random().nextDouble() * (max - min) + min;
+        if (!Double.isInfinite(bound)) {
+            return RandomContext.random().nextDouble(min, bound);
         }
-        return RandomContext.random().nextDouble(min, bound);
+        // max == Double.MAX_VALUE, so nextDouble(min, bound) would reject the infinite bound.
+        // Apply the JDK's overflow-safe halving (see Random.nextDouble(origin, bound)) so the
+        // full [min, max] span never yields Infinity or NaN, mapping the top back to max.
+        double r = RandomContext.random().nextDouble();
+        r = 2.0 * (r * (0.5 * max - 0.5 * min) + 0.5 * min);
+        return r >= max ? max : r;
     }
 
     @Override

--- a/src/main/java/de/cuioss/test/generator/impl/FloatObjectGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/FloatObjectGenerator.java
@@ -23,7 +23,7 @@ import de.cuioss.test.generator.TypedGenerator;
  * <p>Features:</p>
  * <ul>
  *   <li>Configurable range through constructor parameters</li>
- *   <li>Default range: {@link Float#MIN_VALUE} to {@link Float#MAX_VALUE}</li>
+ *   <li>Default range: {@code -Float.MAX_VALUE} to {@link Float#MAX_VALUE} (includes negatives and zero)</li>
  *   <li>Thread-safe implementation</li>
  *   <li>Uses double precision for internal generation to ensure even distribution</li>
  * </ul>
@@ -47,10 +47,10 @@ public class FloatObjectGenerator implements TypedGenerator<Float> {
     private final DoubleGenerator delegate;
 
     /**
-     * Creates a generator for the full float range.
+     * Creates a generator for the full finite float range.
      */
     public FloatObjectGenerator() {
-        this(Float.MIN_VALUE, Float.MAX_VALUE);
+        this(-Float.MAX_VALUE, Float.MAX_VALUE);
     }
 
     /**

--- a/src/main/java/de/cuioss/test/generator/impl/LongGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/LongGenerator.java
@@ -20,11 +20,6 @@ import de.cuioss.test.generator.internal.RandomContext;
 import lombok.AccessLevel;
 import lombok.Getter;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-
-import static java.math.BigDecimal.valueOf;
-
 /**
  * Generates random {@link Long} values within a configurable range.
  *
@@ -63,7 +58,7 @@ public class LongGenerator implements TypedGenerator<Long> {
 
     @Override
     public Long next() {
-        return range < 0 ? bigDecimalImpl() : longImpl();
+        return range < 0 ? wideRangeImpl() : longImpl();
     }
 
     private long longImpl() {
@@ -76,10 +71,20 @@ public class LongGenerator implements TypedGenerator<Long> {
         return min + RandomContext.random().nextLong(range + 1);
     }
 
-    private long bigDecimalImpl() {
-        BigDecimal localRange = valueOf(max).add(valueOf(1L)).subtract(valueOf(min));
-        return valueOf(min).add(valueOf(RandomContext.random().nextDouble()).multiply(localRange))
-                .setScale(0, RoundingMode.FLOOR).longValue();
+    /**
+     * Handles spans whose size {@code (max - min + 1)} exceeds the {@code long} range (i.e. the
+     * computed {@link #range} overflowed to a negative value). A full 64-bit draw is sampled and
+     * rejected until it falls within {@code [min, max]}. Because such a span always covers at least
+     * half of the {@code long} domain, the acceptance probability is {@code >= 0.5} and the expected
+     * number of draws is below two. Unlike a single {@code nextDouble()} scaling, this uses the full
+     * 64 bits of entropy and can reach {@link Long#MAX_VALUE}.
+     */
+    private long wideRangeImpl() {
+        long candidate;
+        do {
+            candidate = RandomContext.random().nextLong();
+        } while (candidate < min || candidate > max);
+        return candidate;
     }
 
     @Override

--- a/src/main/java/de/cuioss/test/generator/impl/PrimitiveArrayGenerators.java
+++ b/src/main/java/de/cuioss/test/generator/impl/PrimitiveArrayGenerators.java
@@ -65,7 +65,7 @@ public enum PrimitiveArrayGenerators {
 
     @Override
     public Object next() {
-        final int size = sizeGenerator.next();
+        final int size = SIZE_GENERATOR.next();
         final var generator = Generators.booleans();
         final var array = new boolean[size];
         for (var index = 0; index < size; index++) {
@@ -84,7 +84,7 @@ public enum PrimitiveArrayGenerators {
 
         @Override
         public Object next() {
-            final int size = sizeGenerator.next();
+            final int size = SIZE_GENERATOR.next();
             final var generator = Generators.bytes();
             final var array = new byte[size];
             for (var index = 0; index < size; index++) {
@@ -103,7 +103,7 @@ public enum PrimitiveArrayGenerators {
 
         @Override
         public Object next() {
-            final int size = sizeGenerator.next();
+            final int size = SIZE_GENERATOR.next();
             final var generator = Generators.characters();
             final var array = new char[size];
             for (var index = 0; index < size; index++) {
@@ -122,7 +122,7 @@ public enum PrimitiveArrayGenerators {
 
         @Override
         public Object next() {
-            final int size = sizeGenerator.next();
+            final int size = SIZE_GENERATOR.next();
             final TypedGenerator<Short> generator = new ShortObjectGenerator();
             final var array = new short[size];
             for (var index = 0; index < size; index++) {
@@ -141,7 +141,7 @@ public enum PrimitiveArrayGenerators {
 
         @Override
         public Object next() {
-            final int size = sizeGenerator.next();
+            final int size = SIZE_GENERATOR.next();
             final var generator = Generators.integers();
             final var array = new int[size];
             for (var index = 0; index < size; index++) {
@@ -160,7 +160,7 @@ public enum PrimitiveArrayGenerators {
 
         @Override
         public Object next() {
-            final int size = sizeGenerator.next();
+            final int size = SIZE_GENERATOR.next();
             final var generator = Generators.longs();
             final var array = new long[size];
             for (var index = 0; index < size; index++) {
@@ -179,7 +179,7 @@ public enum PrimitiveArrayGenerators {
 
         @Override
         public Object next() {
-            final int size = sizeGenerator.next();
+            final int size = SIZE_GENERATOR.next();
             final TypedGenerator<Float> generator = new FloatObjectGenerator();
             final var array = new float[size];
             for (var index = 0; index < size; index++) {
@@ -198,7 +198,7 @@ public enum PrimitiveArrayGenerators {
 
         @Override
         public Object next() {
-            final int size = sizeGenerator.next();
+            final int size = SIZE_GENERATOR.next();
             final var generator = Generators.doubles();
             final var array = new double[size];
             for (var index = 0; index < size; index++) {
@@ -213,7 +213,7 @@ public enum PrimitiveArrayGenerators {
         }
     };
 
-    private static final TypedGenerator<Integer> sizeGenerator = Generators.integers(1, 128);
+    private static final TypedGenerator<Integer> SIZE_GENERATOR = Generators.integers(1, 128);
 
     /**
      * @return an primitive array of the configured type, with the sizes 1-128

--- a/src/main/java/de/cuioss/test/generator/impl/StringGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/StringGenerator.java
@@ -49,6 +49,9 @@ public class StringGenerator implements TypedGenerator<String> {
      * @param maxLen maximum string length (inclusive)
      */
     public StringGenerator(int minLen, int maxLen) {
+        if (minLen < 0) {
+            throw new IllegalArgumentException("minLen must not be negative, given: " + minLen);
+        }
         this.lengthGenerator = new IntegerGenerator(minLen, maxLen);
         this.allowedChars = null;
         this.charGenerator = new CharacterGenerator();
@@ -64,6 +67,9 @@ public class StringGenerator implements TypedGenerator<String> {
     public StringGenerator(String allowedChars, int minLen, int maxLen) {
         if (allowedChars == null || allowedChars.isEmpty()) {
             throw new IllegalArgumentException("allowedChars must not be null or empty");
+        }
+        if (minLen < 0) {
+            throw new IllegalArgumentException("minLen must not be negative, given: " + minLen);
         }
         this.lengthGenerator = new IntegerGenerator(minLen, maxLen);
         this.allowedChars = allowedChars;

--- a/src/main/java/de/cuioss/test/generator/impl/URLGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/URLGenerator.java
@@ -54,7 +54,7 @@ import java.net.URL;
  */
 public class URLGenerator implements TypedGenerator<URL> {
 
-    private static final TypedGenerator<String> generator = Generators.fixedValues(String.class, "https://www.heise.de",
+    private static final TypedGenerator<String> URL_STRINGS = Generators.fixedValues(String.class, "https://www.heise.de",
             "https://stackoverflow.com", "https://github.com/cuioss", "https://www.gitlab.com", "https://sonarcloud.io",
             "https://www.eclipse.org", "https://www.sesamestreet.org/", "https://de.wikipedia.org",
             "https://www.xing.com", "https://www.mozilla.org", "https://avm.de/", "https://www.primefaces.org/",
@@ -64,7 +64,7 @@ public class URLGenerator implements TypedGenerator<URL> {
     @Override
     public URL next() {
         try {
-            return URI.create(generator.next()).toURL();
+            return URI.create(URL_STRINGS.next()).toURL();
         } catch (final MalformedURLException e) {
             throw new IllegalStateException(e);
         }

--- a/src/main/java/de/cuioss/test/generator/impl/UniqueValuesGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/UniqueValuesGenerator.java
@@ -16,10 +16,11 @@
 package de.cuioss.test.generator.impl;
 
 import de.cuioss.test.generator.TypedGenerator;
-import lombok.RequiredArgsConstructor;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Wraps a source generator and ensures all generated values are unique.
@@ -27,22 +28,37 @@ import java.util.Set;
  * @param <T> the type of values to generate
  * @author Oliver Wolff
  */
-@RequiredArgsConstructor
 public class UniqueValuesGenerator<T> implements TypedGenerator<T> {
 
     private static final int DEFAULT_MAX_RETRIES = 100;
 
     private final TypedGenerator<T> source;
     private final int maxRetries;
-    private final Set<T> seen = new HashSet<>();
+    private final Set<T> seen = ConcurrentHashMap.newKeySet();
 
     /**
      * Creates a unique values generator wrapping the given source.
      *
-     * @param source the source generator
+     * @param source the source generator, must not be {@code null}
      */
     public UniqueValuesGenerator(TypedGenerator<T> source) {
         this(source, DEFAULT_MAX_RETRIES);
+    }
+
+    /**
+     * Creates a unique values generator wrapping the given source.
+     *
+     * @param source     the source generator, must not be {@code null}
+     * @param maxRetries the maximum number of attempts to draw a fresh value, must be positive
+     * @throws NullPointerException     if {@code source} is {@code null}
+     * @throws IllegalArgumentException if {@code maxRetries} is not positive
+     */
+    public UniqueValuesGenerator(TypedGenerator<T> source, int maxRetries) {
+        this.source = requireNonNull(source, "source must not be null");
+        if (maxRetries <= 0) {
+            throw new IllegalArgumentException("maxRetries must be greater than 0, given: " + maxRetries);
+        }
+        this.maxRetries = maxRetries;
     }
 
     @Override

--- a/src/test/java/de/cuioss/test/generator/impl/DoubleGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/generator/impl/DoubleGeneratorTest.java
@@ -15,11 +15,15 @@
  */
 package de.cuioss.test.generator.impl;
 
+import de.cuioss.test.generator.junit.EnableGeneratorController;
+import de.cuioss.test.generator.junit.GeneratorSeed;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@EnableGeneratorController
+@GeneratorSeed(42L)
 @DisplayName("DoubleGenerator should")
 class DoubleGeneratorTest {
 
@@ -30,6 +34,51 @@ class DoubleGeneratorTest {
         for (int i = 0; i < 100; i++) {
             assertNotNull(generator.next());
         }
+    }
+
+    @Test
+    @DisplayName("produce only finite, in-range values across the full [-MAX, MAX] span")
+    void shouldProduceFiniteValuesAcrossFullRange() {
+        var generator = new DoubleGenerator(-Double.MAX_VALUE, Double.MAX_VALUE);
+        for (int i = 0; i < 10_000; i++) {
+            double value = generator.next();
+            assertTrue(Double.isFinite(value), "Non-finite value produced: " + value);
+            assertTrue(value >= -Double.MAX_VALUE && value <= Double.MAX_VALUE, "Out of range: " + value);
+        }
+    }
+
+    @Test
+    @DisplayName("reject non-finite bounds in the constructor")
+    void shouldRejectNonFiniteBounds() {
+        assertThrows(IllegalArgumentException.class, () -> new DoubleGenerator(Double.NaN, 1.0));
+        assertThrows(IllegalArgumentException.class, () -> new DoubleGenerator(0.0, Double.POSITIVE_INFINITY));
+        assertThrows(IllegalArgumentException.class, () -> new DoubleGenerator(Double.NEGATIVE_INFINITY, 0.0));
+    }
+
+    @Test
+    @DisplayName("produce negative and positive values with the default full range")
+    void shouldProduceBothSignsByDefault() {
+        var generator = new DoubleGenerator();
+        boolean sawNegative = false;
+        boolean sawPositive = false;
+        for (int i = 0; i < 1_000 && !(sawNegative && sawPositive); i++) {
+            double value = generator.next();
+            sawNegative |= value < 0;
+            sawPositive |= value > 0;
+        }
+        assertTrue(sawNegative, "Default double generator must be able to produce negative values");
+        assertTrue(sawPositive, "Default double generator must be able to produce positive values");
+    }
+
+    @Test
+    @DisplayName("produce negative float values with the default full range")
+    void shouldProduceNegativeFloatsByDefault() {
+        var generator = new FloatObjectGenerator();
+        boolean sawNegative = false;
+        for (int i = 0; i < 1_000 && !sawNegative; i++) {
+            sawNegative = generator.next() < 0;
+        }
+        assertTrue(sawNegative, "Default float generator must be able to produce negative values");
     }
 
     @Test

--- a/src/test/java/de/cuioss/test/generator/impl/LongGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/generator/impl/LongGeneratorTest.java
@@ -16,11 +16,15 @@
 package de.cuioss.test.generator.impl;
 
 import de.cuioss.test.generator.internal.RandomContext;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
+import de.cuioss.test.generator.junit.GeneratorSeed;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@EnableGeneratorController
+@GeneratorSeed(42L)
 @DisplayName("LongGenerator should")
 class LongGeneratorTest {
 
@@ -31,6 +35,46 @@ class LongGeneratorTest {
         for (int i = 0; i < 100; i++) {
             assertNotNull(generator.next());
         }
+    }
+
+    @Test
+    @DisplayName("cover both signs and high-magnitude values across the full long range")
+    void shouldCoverFullLongRange() {
+        var generator = new LongGenerator();
+        boolean sawNegative = false;
+        boolean sawPositive = false;
+        boolean sawHighMagnitude = false;
+        for (int i = 0; i < 10_000; i++) {
+            long value = generator.next();
+            sawNegative |= value < 0;
+            sawPositive |= value > 0;
+            // A single nextDouble() scaling could only reach ~every 2048th value; a full-entropy
+            // draw regularly lands in the top of the range.
+            sawHighMagnitude |= Math.abs(value) > (Long.MAX_VALUE / 2);
+        }
+        assertTrue(sawNegative, "Full-range long generator must produce negative values");
+        assertTrue(sawPositive, "Full-range long generator must produce positive values");
+        assertTrue(sawHighMagnitude, "Full-range long generator must reach high-magnitude values");
+    }
+
+    @Test
+    @DisplayName("distribute uniformly and reach both ends of a wide (> Long.MAX_VALUE) span")
+    void shouldReachEndsOfWideSpan() {
+        // min..max spans more than Long.MAX_VALUE, exercising the wide-range rejection path.
+        long min = Long.MIN_VALUE / 2;
+        long max = Long.MAX_VALUE;
+        var generator = new LongGenerator(min, max);
+        long observedMin = Long.MAX_VALUE;
+        long observedMax = Long.MIN_VALUE;
+        for (int i = 0; i < 20_000; i++) {
+            long value = generator.next();
+            assertTrue(value >= min && value <= max, "Out of range: " + value);
+            observedMin = Math.min(observedMin, value);
+            observedMax = Math.max(observedMax, value);
+        }
+        // Should get within the top and bottom deciles of the span.
+        assertTrue(observedMax > max - (max / 8), "Never approached the upper bound: " + observedMax);
+        assertTrue(observedMin < min / 2, "Never approached the lower bound: " + observedMin);
     }
 
     @Test

--- a/src/test/java/de/cuioss/test/generator/impl/StringGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/generator/impl/StringGeneratorTest.java
@@ -67,6 +67,13 @@ class StringGeneratorTest {
     }
 
     @Test
+    @DisplayName("reject a negative minimum length")
+    void shouldRejectNegativeMinLength() {
+        assertThrows(IllegalArgumentException.class, () -> new StringGenerator(-1, 5));
+        assertThrows(IllegalArgumentException.class, () -> new StringGenerator("ABC", -1, 5));
+    }
+
+    @Test
     @DisplayName("return String.class as type")
     void shouldReturnCorrectType() {
         assertEquals(String.class, new StringGenerator().getType());

--- a/src/test/java/de/cuioss/test/generator/impl/UniqueValuesGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/generator/impl/UniqueValuesGeneratorTest.java
@@ -16,14 +16,25 @@
 package de.cuioss.test.generator.impl;
 
 import de.cuioss.test.generator.TypedGenerator;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
+import de.cuioss.test.generator.junit.GeneratorSeed;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@EnableGeneratorController
+@GeneratorSeed(42L)
 @DisplayName("UniqueValuesGenerator should")
 class UniqueValuesGeneratorTest {
 
@@ -54,5 +65,54 @@ class UniqueValuesGeneratorTest {
         var source = new IntegerGenerator();
         var generator = new UniqueValuesGenerator<>(source);
         assertEquals(Integer.class, generator.getType());
+    }
+
+    @Test
+    @DisplayName("validate constructor arguments")
+    void shouldValidateConstructorArguments() {
+        var source = new IntegerGenerator();
+        assertThrows(NullPointerException.class, () -> new UniqueValuesGenerator<>(null));
+        assertThrows(NullPointerException.class, () -> new UniqueValuesGenerator<>(null, 5));
+        assertThrows(IllegalArgumentException.class, () -> new UniqueValuesGenerator<>(source, 0));
+        assertThrows(IllegalArgumentException.class, () -> new UniqueValuesGenerator<>(source, -1));
+    }
+
+    @Test
+    @DisplayName("remain thread-safe under concurrent access")
+    void shouldRemainThreadSafeUnderConcurrency() throws Exception {
+        var source = new IntegerGenerator(0, 1_000_000);
+        var generator = new UniqueValuesGenerator<>(source, 1_000);
+
+        int threads = 8;
+        int perThread = 200;
+        Set<Integer> collected = ConcurrentHashMap.newKeySet();
+        var duplicates = new AtomicInteger();
+        var errors = new AtomicInteger();
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        var latch = new CountDownLatch(threads);
+
+        for (int t = 0; t < threads; t++) {
+            pool.submit(() -> {
+                try {
+                    for (int i = 0; i < perThread; i++) {
+                        Integer value = generator.next();
+                        if (!collected.add(value)) {
+                            duplicates.incrementAndGet();
+                        }
+                    }
+                } catch (RuntimeException e) {
+                    errors.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue(latch.await(30, TimeUnit.SECONDS), "Concurrent generation timed out");
+        pool.shutdownNow();
+
+        assertEquals(0, errors.get(), "Concurrent generation must not raise exceptions");
+        assertEquals(0, duplicates.get(), "Concurrent generation must not yield duplicates");
+        assertEquals(threads * perThread, collected.size());
     }
 }


### PR DESCRIPTION
## Summary

Fixes the core generator correctness defects from `doc/review-26-07-04.md` (PR 4 of 7).

- **C-1** — `DoubleGenerator` full-range fallback no longer overflows to `Infinity`/`NaN`; it uses the JDK's overflow-safe halving over `[min, max]`.
- **C-2** — the `DoubleGenerator(min, max)` constructor rejects non-finite bounds up front.
- **C-3 ⚠️** — no-arg `doubles()`/`floats()`/`doubleObjects()`/`floatObjects()` now span the **full finite range** (`-MAX … MAX`), so negatives and zero are produced. Previously the lower bound was `MIN_VALUE` (smallest *positive* value).
- **C-4 ⚠️** — `LongGenerator` samples wide spans (`> Long.MAX_VALUE`, e.g. default `longs()`) via full-entropy rejection instead of a single `nextDouble()`, so the full 64 bits are used and `Long.MAX_VALUE` is reachable.
- **C-5** — `StringGenerator` rejects a negative minimum length in both size-taking constructors (was an intermittent `NegativeArraySizeException`).
- **C-6** — `UniqueValuesGenerator` backs its seen-set with `ConcurrentHashMap.newKeySet()`, honoring the thread-safety contract.
- **C-7** — `UniqueValuesGenerator` gains an explicit validating constructor (non-null source, positive `maxRetries`).
- **C-8** — `Generators.letterStrings()` draws a fresh length per value and the "mininmal" typo is fixed.
- **C-9** — `timeZones()`/`zoneIds()` reuse cached static lists instead of rebuilding ~600 entries per call.
- **C-10** — the first-element type helper is renamed to `determineTypeFromFirstElement`, documented accurately, and null-guarded.
- **C-11** — `enumValues()` validates the argument is an enum (clear IAE instead of an NPE).
- **C-12** — `URLGenerator.URL_STRINGS` and `PrimitiveArrayGenerators.SIZE_GENERATOR` renamed to `UPPER_SNAKE_CASE`.

## ⚠️ Decisions (behavior changes for fixed seeds — recommended in the review)
- **C-3**: default `doubles()`/`floats()` now include negatives and zero.
- **C-4**: full-range `longs()` (and transitively `DateGenerator`) use a different value stream for a given seed.

## Tests
Finite/both-signs full-range doubles (C-1, C-3), non-finite bound rejection (C-2), full/wide-range long coverage & end reachability (C-4), negative-size IAE (C-5), concurrent uniqueness + constructor validation (C-6, C-7).

## Verification
`./mvnw -Ppre-commit clean install` — green, clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhVybFv6iGrJNXo5Ekg5YA)_