### PR TITLE
fix: domain generator correctness (D-1..D-10)

### DIFF
--- a/src/main/java/de/cuioss/test/generator/domain/BlindTextGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/domain/BlindTextGenerator.java
@@ -69,4 +69,9 @@ public class BlindTextGenerator implements TypedGenerator<String> {
         return contents.next();
     }
 
+    @Override
+    public Class<String> getType() {
+        return String.class;
+    }
+
 }

--- a/src/main/java/de/cuioss/test/generator/domain/DistinguishedNamesGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/domain/DistinguishedNamesGenerator.java
@@ -57,7 +57,7 @@ import static de.cuioss.test.generator.Generators.integers;
 public class DistinguishedNamesGenerator implements TypedGenerator<String> {
 
     private final TypedGenerator<String> prefixes = fixedValues("ou", "o", "dc");
-    private final TypedGenerator<String> values = fixedValues("proxies", "ID", "dc", "accounts", "groups", "roles",
+    private final TypedGenerator<String> values = fixedValues("proxies", "ID", "accounts", "groups", "roles",
             "services");
 
     @Override

--- a/src/main/java/de/cuioss/test/generator/domain/EmailGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/domain/EmailGenerator.java
@@ -17,6 +17,7 @@ package de.cuioss.test.generator.domain;
 
 import de.cuioss.test.generator.TypedGenerator;
 
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -60,14 +61,22 @@ public class EmailGenerator implements TypedGenerator<String> {
         return createEmail(firstNames.next(), familyNames.next());
     }
 
+    @Override
+    public Class<String> getType() {
+        return String.class;
+    }
+
     /**
-     * Creates an email address from given first and last names.
-     * All components are converted to lowercase.
+     * Creates an email address from the given first and last names, lowercased using
+     * {@link Locale#ROOT} so the result is locale-independent.
      *
-     * @param firstname The person's first name, must not be null or empty
-     * @param lastname  The person's last name, must not be null or empty
-     * @return An email address in the format firstname.lastname@domain.tld.
-     * Returns "invalid.email@example.com" if either name component is null or empty.
+     * @param firstname the person's first name; a {@code null} or blank value triggers a
+     *                  fallback address
+     * @param lastname  the person's last name; a {@code null} or blank value triggers a
+     *                  fallback address
+     * @return an email address in the format firstname.lastname@domain.tld, or
+     *         {@code "invalid.email@example.com"} if either name component is {@code null}
+     *         or blank
      */
     public static String createEmail(final String firstname, final String lastname) {
         if (firstname == null || firstname.isBlank() || lastname == null || lastname.isBlank()) {
@@ -75,7 +84,7 @@ public class EmailGenerator implements TypedGenerator<String> {
             return "invalid.email@example.com";
         }
         var tld = TLDS.next();
-        var email = (firstname + "." + lastname + "@" + DOMAINS.next()).toLowerCase();
+        var email = (firstname + "." + lastname + "@" + DOMAINS.next()).toLowerCase(Locale.ROOT);
         var fullEmail = email + '.' + tld;
         LOGGER.log(Level.FINE, "Generated email: {0}", fullEmail);
         return fullEmail;

--- a/src/main/java/de/cuioss/test/generator/domain/FullNameGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/domain/FullNameGenerator.java
@@ -57,12 +57,13 @@ public class FullNameGenerator implements TypedGenerator<String> {
 
     /**
      * Creates a new FullNameGenerator for the specified locale.
-     * 
-     * @param locale Determines the name set to use. If {@link Locale#GERMAN}, German names will be used;
-     *              for all other locales, English names will be used.
+     *
+     * @param locale Determines the name set to use. Any German-language locale (e.g.
+     *              {@link Locale#GERMAN}, {@link Locale#GERMANY}, de_AT, de_CH) selects German
+     *              names; all other (and {@code null}) locales use English names.
      */
     public FullNameGenerator(final Locale locale) {
-        if (Locale.GERMAN.equals(locale)) {
+        if (locale != null && "de".equals(locale.getLanguage())) {
             firstNames = NameGenerators.FIRSTNAMES_ANY_GERMAN.generator();
             familyNames = NameGenerators.FAMILY_NAMES_GERMAN.generator();
         } else {
@@ -74,6 +75,11 @@ public class FullNameGenerator implements TypedGenerator<String> {
     @Override
     public String next() {
         return firstNames.next() + ' ' + familyNames.next();
+    }
+
+    @Override
+    public Class<String> getType() {
+        return String.class;
     }
 
 }

--- a/src/main/java/de/cuioss/test/generator/domain/MailSubjectGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/domain/MailSubjectGenerator.java
@@ -67,13 +67,20 @@ public class MailSubjectGenerator implements TypedGenerator<String> {
     @Override
     public String next() {
         final List<String> elements = new ArrayList<>();
-        for (var i = 0; i < prefixCountGenerator.next(); i++) {
+        final int prefixCount = prefixCountGenerator.next();
+        for (var i = 0; i < prefixCount; i++) {
             elements.add(prefixes.next());
         }
-        for (var i = 0; i < contentCountGenerator.next(); i++) {
+        final int contentCount = contentCountGenerator.next();
+        for (var i = 0; i < contentCount; i++) {
             elements.add(contents.next());
         }
         return String.join(" ", elements);
+    }
+
+    @Override
+    public Class<String> getType() {
+        return String.class;
     }
 
 }

--- a/src/main/java/de/cuioss/test/generator/domain/PersonGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/domain/PersonGenerator.java
@@ -55,10 +55,6 @@ public class PersonGenerator implements TypedGenerator<Person> {
         final var organization = organizations.next();
         final var title = titles.next();
 
-        if (null == firstname || null == lastname) {
-            LOGGER.log(Level.WARNING, "Generated null name components: firstname={0}, lastname={1}", new Object[]{firstname, lastname});
-        }
-
         var person = Person.builder()
                 .email(EmailGenerator.createEmail(firstname, lastname))
                 .firstname(firstname)
@@ -69,6 +65,11 @@ public class PersonGenerator implements TypedGenerator<Person> {
 
         LOGGER.log(Level.FINE, "Generated person: {0} {1}", new Object[]{firstname, lastname});
         return person;
+    }
+
+    @Override
+    public Class<Person> getType() {
+        return Person.class;
     }
 
 }

--- a/src/main/java/de/cuioss/test/generator/domain/UUIDGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/domain/UUIDGenerator.java
@@ -22,7 +22,8 @@ import java.util.UUID;
 import static de.cuioss.test.generator.Generators.longs;
 
 /**
- * Creates instances of UUIDs
+ * Creates random RFC 4122 version-4 (variant 2) {@link UUID} instances, so that
+ * {@link UUID#version()} returns {@code 4} and {@link UUID#variant()} returns {@code 2}.
  */
 public class UUIDGenerator implements TypedGenerator<UUID> {
 
@@ -31,7 +32,18 @@ public class UUIDGenerator implements TypedGenerator<UUID> {
 
     @Override
     public UUID next() {
-        return new UUID(mostSignificantBits.next(), leastSignificantBits.next());
+        long most = mostSignificantBits.next();
+        long least = leastSignificantBits.next();
+        most &= 0xFFFF_FFFF_FFFF_0FFFL;
+        most |= 0x0000_0000_0000_4000L; // version 4
+        least &= 0x3FFF_FFFF_FFFF_FFFFL;
+        least |= 0x8000_0000_0000_0000L; // IETF variant (variant 2)
+        return new UUID(most, least);
+    }
+
+    @Override
+    public Class<UUID> getType() {
+        return UUID.class;
     }
 
 }

--- a/src/main/java/de/cuioss/test/generator/domain/ZipCodeGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/domain/ZipCodeGenerator.java
@@ -21,33 +21,30 @@ import static de.cuioss.test.generator.Generators.integers;
 
 /**
  * Generates German postal codes (Postleitzahlen) for test data generation.
- * 
+ *
  * <p>Characteristics:</p>
  * <ul>
- *   <li>Generates 5-digit postal codes</li>
- *   <li>Range: 10000 - 99999</li>
- *   <li>Format matches official German postal code format</li>
+ *   <li>Range: 1067 - 99999, covering the valid German codes from 01067 (Dresden) upward</li>
+ *   <li>Returned as {@link Integer}; codes below 10000 represent leading-zero codes such as
+ *       01067 and must be formatted with {@code %05d} for display</li>
  * </ul>
- * 
+ *
  * <p><em>Example usage:</em></p>
  * <pre>
  * var generator = new ZipCodeGenerator();
- * Integer zipCode = generator.next(); // e.g. 12345
- * String formattedZip = String.format("%05d", zipCode); // Ensures 5 digits with leading zeros
+ * Integer zipCode = generator.next(); // e.g. 1067 or 12345
+ * String formattedZip = String.format("%05d", zipCode); // e.g. "01067", "12345"
  * </pre>
- * 
- * <p>Note: This generator returns {@link Integer} values. For display purposes,
- * you may want to format the number to ensure it always shows 5 digits.</p>
  *
  * @author Oliver Wolff
  */
 public class ZipCodeGenerator implements TypedGenerator<Integer> {
 
-    private final TypedGenerator<Integer> zibCodes = integers(10000, 99999);
+    private final TypedGenerator<Integer> zipCodes = integers(1067, 99999);
 
     @Override
     public Integer next() {
-        return zibCodes.next();
+        return zipCodes.next();
     }
 
     @Override

--- a/src/test/java/de/cuioss/test/generator/domain/DomainGeneratorFixesTest.java
+++ b/src/test/java/de/cuioss/test/generator/domain/DomainGeneratorFixesTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.generator.domain;
+
+import de.cuioss.test.generator.internal.RandomContext;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
+import de.cuioss.test.generator.junit.GeneratorSeed;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnableGeneratorController
+@GeneratorSeed(42L)
+@DisplayName("Domain generator fixes")
+class DomainGeneratorFixesTest {
+
+    @Test
+    @DisplayName("expose a static getType() that consumes no RNG draw (D-5)")
+    void getTypeShouldReturnStaticTypeWithoutConsumingDraws() {
+        assertEquals(String.class, new BlindTextGenerator().getType());
+        assertEquals(String.class, new EmailGenerator().getType());
+        assertEquals(String.class, new FullNameGenerator().getType());
+        assertEquals(String.class, new MailSubjectGenerator().getType());
+        assertEquals(Person.class, new PersonGenerator().getType());
+        assertEquals(UUID.class, new UUIDGenerator().getType());
+
+        RandomContext.setSeed(7L);
+        var first = new EmailGenerator().next();
+        var second = new EmailGenerator().next();
+
+        RandomContext.setSeed(7L);
+        var generator = new EmailGenerator();
+        var firstAgain = generator.next();
+        generator.getType();
+        var secondAgain = generator.next();
+
+        assertEquals(first, firstAgain);
+        assertEquals(second, secondAgain, "getType() must not consume RNG draws");
+    }
+
+    @Test
+    @DisplayName("build locale-independent email addresses (D-2)")
+    void createEmailShouldBeLocaleIndependent() {
+        var previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            var email = EmailGenerator.createEmail("Isabella", "Ingram");
+            assertTrue(email.startsWith("isabella.ingram@"), email);
+            assertFalse(email.contains("ı"), "Must not contain a locale-dependent dotless i: " + email);
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+
+    @Test
+    @DisplayName("keep the mail-subject prefix count within its documented 0-3 bound (D-1)")
+    void mailSubjectShouldStayWithinDocumentedBounds() {
+        var prefixes = Set.of("Re:", "Fw:", "Answ:", "Yep:");
+        var generator = new MailSubjectGenerator();
+        for (int i = 0; i < 2_000; i++) {
+            var subject = generator.next();
+            // Prefixes are single tokens drawn first; content words (some containing spaces) follow.
+            var tokens = subject.isBlank() ? new String[0] : subject.split(" ");
+            int leadingPrefixes = 0;
+            for (var token : tokens) {
+                if (!prefixes.contains(token)) {
+                    break;
+                }
+                leadingPrefixes++;
+            }
+            assertTrue(leadingPrefixes <= 3, "At most 3 prefixes expected, got: " + subject);
+        }
+    }
+
+    @Test
+    @DisplayName("generate reproducible mail subjects for a fixed seed (D-1)")
+    void mailSubjectShouldBeReproducible() {
+        RandomContext.setSeed(5L);
+        var first = new MailSubjectGenerator().next();
+        RandomContext.setSeed(5L);
+        var second = new MailSubjectGenerator().next();
+        assertEquals(first, second);
+    }
+
+    @Test
+    @DisplayName("generate zip codes covering the leading-zero range (D-7)")
+    void zipCodesShouldCoverLeadingZeroRange() {
+        var generator = new ZipCodeGenerator();
+        boolean sawLeadingZeroCode = false;
+        for (int i = 0; i < 5_000; i++) {
+            int zip = generator.next();
+            assertTrue(zip >= 1067 && zip <= 99999, "Out of range: " + zip);
+            if (zip < 10000) {
+                sawLeadingZeroCode = true;
+            }
+        }
+        assertTrue(sawLeadingZeroCode, "Must be able to produce codes below 10000 (leading-zero codes)");
+    }
+
+    @Test
+    @DisplayName("never use the attribute prefix 'dc' as a DN value (D-8)")
+    void distinguishedNamesShouldNotUseDcAsValue() {
+        var generator = new DistinguishedNamesGenerator();
+        for (int i = 0; i < 500; i++) {
+            var dn = generator.next();
+            for (var component : dn.split(",")) {
+                var value = component.substring(component.indexOf('=') + 1);
+                assertNotEquals("dc", value, "A DN value must not be the attribute prefix 'dc': " + dn);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("use German names for German-language locale variants (D-9)")
+    void germanLocaleVariantsShouldUseGermanNames() {
+        RandomContext.setSeed(3L);
+        var fromGerman = new FullNameGenerator(Locale.GERMAN).next();
+        RandomContext.setSeed(3L);
+        var fromGermany = new FullNameGenerator(Locale.GERMANY).next();
+        assertEquals(fromGerman, fromGermany, "Locale.GERMANY must use the same German name set as Locale.GERMAN");
+    }
+
+    @Test
+    @DisplayName("produce RFC 4122 version-4 UUIDs (D-10)")
+    void uuidsShouldBeRfc4122Version4() {
+        var generator = new UUIDGenerator();
+        for (int i = 0; i < 1_000; i++) {
+            var uuid = generator.next();
+            assertEquals(4, uuid.version(), "Expected a version-4 UUID");
+            assertEquals(2, uuid.variant(), "Expected the IETF variant");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the domain-generator defects from `doc/review-26-07-04.md` (PR 5 of 7).

- **D-1** — `MailSubjectGenerator` hoists the prefix/content counts out of the loop conditions, restoring the documented uniform 0-3 / 0-7 distribution and avoiding extra RNG draws.
- **D-2** — `EmailGenerator` lowercases with `Locale.ROOT` (locale-independent; no dotless-i on a Turkish JVM).
- **D-3** — `createEmail` Javadoc now describes the lenient null/blank fallback accurately.
- **D-4** — removed the dead null-check on names in `PersonGenerator` (`FixedValuesGenerator` never returns null).
- **D-5** — `getType()` is overridden to return the static type on `BlindText`/`Email`/`FullName`/`MailSubject`/`Person`/`UUID` generators, so calling it no longer silently consumes shared-RNG draws.
- **D-6 / D-7** — fixed the `zibCodes` typo and widened the range to `1067-99999`, covering the valid leading-zero codes (01067 upward); returned as `Integer`, format with `%05d`.
- **D-8** — dropped the stray `"dc"` value from `DistinguishedNamesGenerator` (it produced components like `ou=dc`).
- **D-9** — `FullNameGenerator` selects German names for any German-language locale (`GERMANY`, `de_AT`, `de_CH`), with a null guard.
- **D-10 ⚠️** — `UUIDGenerator` sets the RFC 4122 version-4 and IETF variant bits, so `uuid.version() == 4` and `uuid.variant() == 2`.

## ⚠️ Decision (behavior change for fixed seeds — recommended in the review)
- **D-10**: UUIDs now carry the v4/variant bits, changing the generated values for a given seed.
- **D-7**: the zip-code range now includes codes below 10000.

## Tests
`getType()`-consumes-no-draw (D-5), locale-safe email (D-2), mail-subject prefix bound & reproducibility (D-1), zip leading-zero range (D-7), DN components (D-8), German locale variants (D-9), UUID version/variant (D-10).

## Verification
`./mvnw -Ppre-commit clean install` — green, clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhVybFv6iGrJNXo5Ekg5YA)_