### PR TITLE
docs: Javadoc &amp; guide truthfulness (E-1..E-19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Each approach uses an `ArgumentsProvider` implementation that:
 - Project uses Maven Wrapper (mvnw) - no local Maven installation needed
 - Java 21+ required (configured via parent POM)
 - Dependencies managed through cui-java-parent POM
-- Main dependencies: JUnit 5, Lombok, cui-java-tools
+- Main dependencies: JUnit 5, Lombok (EasyMock is test-only)
 
 ## Git Workflow
 
@@ -118,10 +118,6 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
 1. Create a feature branch: `git checkout -b <branch-name>`
 2. Commit changes: `git add <files> && git commit -m "<message>"`
 3. Push the branch: `git push -u origin <branch-name>`
-4. Create a PR: `gh pr create --head <branch-name> --base main --title "<title>" --body "<body>"`
-5. Enable auto-merge: `gh pr merge --auto --squash --delete-branch`
-6. Wait for merge (check every ~60s): `while gh pr view --json state -q '.state' | grep -q OPEN; do sleep 60; done`
-7. Return to main: `git checkout main && git pull`
 4. Create a PR: `gh pr create --repo cuioss/cui-test-generator --head <branch-name> --base main --title "<title>" --body "<body>"`
 5. Wait for CI + Gemini review (waits until checks complete): `gh pr checks --watch`
 6. **Handle Gemini review comments** — fetch with `gh api repos/cuioss/cui-test-generator/pulls/<pr-number>/comments` and for each:

--- a/README.adoc
+++ b/README.adoc
@@ -27,8 +27,12 @@ The CUI Test Generator framework provides robust and reproducible test data gene
 <dependency>
     <groupId>de.cuioss.test</groupId>
     <artifactId>cui-test-generator</artifactId>
+    <version>x.y.z</version> <!-- omit when the version is managed by cui-java-bom -->
 </dependency>
 ----
+
+NOTE: If your build imports `de.cuioss:cui-java-bom`, the `<version>` is managed for you and
+can be omitted; otherwise replace `x.y.z` with the desired release version.
 
 === Core Components
 

--- a/src/main/java/de/cuioss/test/generator/Generators.java
+++ b/src/main/java/de/cuioss/test/generator/Generators.java
@@ -61,7 +61,12 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Provides factory methods for creating {@link TypedGenerator}s for various Java types.
- * All generators are thread-safe and suitable for concurrent use in tests.
+ * <p>
+ * Generators are thread-safe for value generation. Reproducibility via a fixed seed is
+ * guaranteed only for single-threaded execution: because all generators share one
+ * {@link java.util.Random} instance, concurrent use interleaves draws and makes the value
+ * stream non-deterministic.
+ * </p>
  *
  * <p>The generators are organized into the following categories:</p>
  * <ul>
@@ -122,10 +127,10 @@ public class Generators {
      * </pre>
      *
      * @param <T> The enum type
-     * @param type to be checked, must represent an enum
+     * @param type to be checked; a {@code null} or non-enum type yields
+     *             {@link Optional#empty()}
      * @return an {@link Optional} containing the corresponding {@link TypedGenerator} if
      *         the given type is an enum, {@link Optional#empty()} otherwise
-     * @throws NullPointerException if type is null
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static <T> Optional<TypedGenerator<T>> enumValuesIfAvailable(final Class<T> type) {
@@ -211,8 +216,8 @@ public class Generators {
     }
 
     /**
-     * Factory method for creating a {@link TypedGenerator} for any Strings, may be
-     * null or empty.
+     * Factory method for creating a {@link TypedGenerator} for arbitrary Strings, which may
+     * be empty but are never {@code null}.
      *
      * @return a {@link TypedGenerator} for Strings
      */
@@ -246,16 +251,16 @@ public class Generators {
      * Factory method for creating a {@link TypedGenerator} for a number of fixed
      * values.
      *
-     * <p><em>Example from tests:</em></p>
+     * <p>Values are selected <em>randomly</em> from the supplied set, not in order.</p>
+     *
+     * <p><em>Example:</em></p>
      * <pre>
      * TypedGenerator&lt;String&gt; generator = Generators.fixedValues("A", "B", "C");
-     * assertEquals("A", generator.next());
-     * assertEquals("B", generator.next());
-     * assertEquals("C", generator.next());
-     * assertEquals("A", generator.next()); // Cycles back to start
+     * assertTrue(Set.of("A", "B", "C").contains(generator.next()));
      * </pre>
      *
      * @param <T> The type of values
+     * @param type of the value
      * @param values to be generated from.
      * @return a {@link TypedGenerator} for the given values
      * @throws IllegalArgumentException if values is empty
@@ -268,10 +273,13 @@ public class Generators {
 
     /**
      * Factory method for creating a {@link TypedGenerator} for a number of fixed
-     * values.
+     * values. The value type is inferred from the runtime class of the first element.
      *
+     * @param <T> The type of values
      * @param values to be generated from.
      * @return a {@link TypedGenerator} for the given values
+     * @throws IllegalArgumentException if values is empty
+     * @throws NullPointerException if values is null or its first element is null
      */
     @SafeVarargs
     public static <T> TypedGenerator<T> fixedValues(final T... values) {
@@ -522,11 +530,12 @@ public class Generators {
     }
 
     /**
-     * Factory method for creating a {@link TypedGenerator} for Long primitives.
+     * Factory method for creating a {@link TypedGenerator} for {@link Long} values in the
+     * given range.
      *
      * @param low  lower bound of range
      * @param high upper bound of range
-     * @return a {@link TypedGenerator} for long primitives
+     * @return a {@link TypedGenerator} for {@link Long}
      */
     public static TypedGenerator<Long> longs(final long low, final long high) {
         return new LongGenerator(low, high);

--- a/src/main/java/de/cuioss/test/generator/TypedGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/TypedGenerator.java
@@ -51,15 +51,16 @@ public interface TypedGenerator<T> {
 
     /**
      * Provides type information about what kind of objects this generator creates.
-     * The default implementation uses the first non-null result from {@link #next()}
-     * to determine the type.
+     * The default implementation calls {@link #next()} once and reads the class of the
+     * returned value.
      *
-     * <p><strong>Note:</strong> If your generator may return null values or the generated
-     * type differs from the actual instance type, you should override this method.</p>
+     * <p><strong>Side effect:</strong> because it invokes {@link #next()}, the default
+     * implementation consumes one value from the shared random stream. Implementations that
+     * must keep the stream deterministic (and any that may return {@code null}) should
+     * override this method to return the type directly.</p>
      *
      * @return The class information indicating which type this generator is responsible for.
-     * @throws IllegalStateException if the generator cannot determine the type, for example
-     *                               if {@link #next()} consistently returns null
+     * @throws NullPointerException if {@link #next()} returns {@code null}
      */
     @SuppressWarnings("unchecked") // the implicit providing of the type is the actual idea
     default Class<T> getType() {

--- a/src/main/java/de/cuioss/test/generator/domain/UUIDStringGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/domain/UUIDStringGenerator.java
@@ -23,7 +23,8 @@ import java.util.logging.Logger;
 
 /**
  * Generates random UUID strings in the standard 8-4-4-4-12 format (e.g. "550e8400-e29b-41d4-a716-446655440000").
- * The generator is thread-safe and produces reproducible results when using the same seed.
+ * The generator is thread-safe for generation; reproducibility for a fixed seed is guaranteed
+ * only under single-threaded execution (all generators share one random source).
  * 
  * <p><em>Example usage from tests:</em></p>
  * <pre>

--- a/src/main/java/de/cuioss/test/generator/domain/package-info.java
+++ b/src/main/java/de/cuioss/test/generator/domain/package-info.java
@@ -60,8 +60,8 @@
  * <ul>
  *   <li>Realistic data for visual/integration testing</li>
  *   <li>Technical variants for unit testing</li>
- *   <li>Thread-safe operation</li>
- *   <li>Deterministic output when seeded</li>
+ *   <li>Thread-safe generation</li>
+ *   <li>Deterministic output when seeded, under single-threaded execution</li>
  * </ul>
  * 
  * <p><em>Example usage:</em></p>

--- a/src/main/java/de/cuioss/test/generator/impl/BooleanGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/BooleanGenerator.java
@@ -22,6 +22,7 @@ import de.cuioss.test.generator.internal.RandomContext;
  * Generates random {@link Boolean} values.
  *
  * @author Oliver Wolff
+ * @since 1.0
  */
 public class BooleanGenerator implements TypedGenerator<Boolean> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/ByteGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/ByteGenerator.java
@@ -21,6 +21,7 @@ import de.cuioss.test.generator.TypedGenerator;
  * Generates random {@link Byte} values within the full byte range.
  *
  * @author Oliver Wolff
+ * @since 1.0
  */
 public class ByteGenerator implements TypedGenerator<Byte> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/CharacterGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/CharacterGenerator.java
@@ -24,6 +24,7 @@ import de.cuioss.test.generator.TypedGenerator;
  * </p>
  *
  * @author Oliver Wolff
+ * @since 1.0
  */
 public class CharacterGenerator implements TypedGenerator<Character> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/CollectionGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/CollectionGenerator.java
@@ -55,12 +55,13 @@ import static java.util.Objects.requireNonNull;
  * // Generate collections
  * List<Integer> list = collectionGen.list(5);      // List of 5 integers
  * Set<Integer> set = collectionGen.set(3);         // Set of 3 integers
- * Collection<Integer> coll = collectionGen.next(); // Random size collection
+ * Integer value = collectionGen.next();            // A single element (see list()/set() for collections)
  * }
  * </pre>
  *
  * @param <T> The type of elements to be generated
  * @author Oliver Wolff
+ * @since 1.0
  */
 public class CollectionGenerator<T> implements TypedGenerator<T> {
 
@@ -91,9 +92,9 @@ public class CollectionGenerator<T> implements TypedGenerator<T> {
      *
      * @param wrapped    generator, must not be null
      * @param lowerBound defines the lower bound of the integer generator that
-     *                   determines the of {@link Collection} size
+     *                   determines the {@link Collection} size
      * @param upperBound defines the upper bound of the integer generator that
-     *                   determines the of {@link Collection} size
+     *                   determines the {@link Collection} size
      */
     public CollectionGenerator(final TypedGenerator<T> wrapped, final int lowerBound, final int upperBound) {
         this(wrapped, Generators.integers(lowerBound, upperBound));

--- a/src/main/java/de/cuioss/test/generator/impl/DateGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/DateGenerator.java
@@ -23,6 +23,7 @@ import java.util.Date;
  * Generates random {@link Date} instances.
  *
  * @author Oliver Wolff
+ * @since 1.0
  */
 public class DateGenerator implements TypedGenerator<Date> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/DecoratorGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/DecoratorGenerator.java
@@ -57,6 +57,7 @@ import lombok.ToString;
  * @author Oliver Wolff
  * @param <T> The type of elements to be generated
  * @see TypedGenerator
+ * @since 1.0
  */
 @RequiredArgsConstructor
 @ToString(of = "type")

--- a/src/main/java/de/cuioss/test/generator/impl/DoubleGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/DoubleGenerator.java
@@ -28,6 +28,7 @@ import lombok.Getter;
  * </p>
  *
  * @author Oliver Wolff
+ * @since 1.0
  */
 @Getter
 public class DoubleGenerator implements TypedGenerator<Double> {

--- a/src/main/java/de/cuioss/test/generator/impl/FixedValuesGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/FixedValuesGenerator.java
@@ -27,6 +27,7 @@ import java.util.List;
  *
  * @param <T> the type of values to generate
  * @author Oliver Wolff
+ * @since 1.0
  */
 public class FixedValuesGenerator<T> implements TypedGenerator<T> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/FloatObjectGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/FloatObjectGenerator.java
@@ -41,6 +41,7 @@ import de.cuioss.test.generator.TypedGenerator;
  * 
  * @author Oliver Wolff
  * @see DoubleGenerator
+ * @since 1.0
  */
 public class FloatObjectGenerator implements TypedGenerator<Float> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/IntegerGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/IntegerGenerator.java
@@ -23,6 +23,7 @@ import lombok.Getter;
  * Generates random {@link Integer} values within a configurable range.
  *
  * @author Oliver Wolff
+ * @since 1.0
  */
 @Getter
 public class IntegerGenerator implements TypedGenerator<Integer> {

--- a/src/main/java/de/cuioss/test/generator/impl/LocalDateGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/LocalDateGenerator.java
@@ -57,6 +57,7 @@ import java.time.LocalDate;
  * @author Eugen Fischer
  * @see LocalDate
  * @see LongGenerator
+ * @since 1.0
  */
 public class LocalDateGenerator implements TypedGenerator<LocalDate> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/LocalDateTimeGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/LocalDateTimeGenerator.java
@@ -43,6 +43,7 @@ import java.time.LocalDateTime;
  * @author Eugen Fischer
  * @see LocalDateGenerator
  * @see LocalTimeGenerator
+ * @since 1.0
  */
 public class LocalDateTimeGenerator implements TypedGenerator<LocalDateTime> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/LocalTimeGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/LocalTimeGenerator.java
@@ -59,6 +59,7 @@ import java.time.LocalTime;
  * @author Eugen Fischer
  * @see LocalTime
  * @see Generators#integers(int, int)
+ * @since 1.0
  */
 public class LocalTimeGenerator implements TypedGenerator<LocalTime> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/LongGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/LongGenerator.java
@@ -24,6 +24,7 @@ import lombok.Getter;
  * Generates random {@link Long} values within a configurable range.
  *
  * @author Oliver Wolff
+ * @since 1.0
  */
 @Getter
 public class LongGenerator implements TypedGenerator<Long> {

--- a/src/main/java/de/cuioss/test/generator/impl/NonBlankStringGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/NonBlankStringGenerator.java
@@ -44,6 +44,7 @@ import static de.cuioss.test.generator.Generators.nonEmptyStrings;
  *
  * @author Oliver Wolff
  * @see de.cuioss.test.generator.Generators#nonEmptyStrings()
+ * @since 1.0
  */
 public class NonBlankStringGenerator implements TypedGenerator<String> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/NumberGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/NumberGenerator.java
@@ -57,6 +57,7 @@ import static de.cuioss.test.generator.Generators.integers;
  * @author Oliver Wolff
  * @see Number
  * @see de.cuioss.test.generator.Generators#integers()
+ * @since 1.0
  */
 public class NumberGenerator implements TypedGenerator<Number> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/PrimitiveArrayGenerators.java
+++ b/src/main/java/de/cuioss/test/generator/impl/PrimitiveArrayGenerators.java
@@ -57,6 +57,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @author Oliver Wolff
  * @see Generators
+ * @since 1.0
  */
 public enum PrimitiveArrayGenerators {
 
@@ -216,7 +217,7 @@ public enum PrimitiveArrayGenerators {
     private static final TypedGenerator<Integer> SIZE_GENERATOR = Generators.integers(1, 128);
 
     /**
-     * @return an primitive array of the configured type, with the sizes 1-128
+     * @return a primitive array of the configured type, with a size between 1 and 128
      */
     public abstract Object next();
 
@@ -228,9 +229,11 @@ public enum PrimitiveArrayGenerators {
     /**
      * Returns a {@link PrimitiveArrayGenerators} for the given primitive type.
      *
-     * @param primitiveType must not be null and a primitive type.
-     * @return the found {@link PrimitiveArrayGenerators} or throws an
-     *         {@link IllegalStateException} if none could be found
+     * @param primitiveType must not be null and must be a primitive type
+     * @return the matching {@link PrimitiveArrayGenerators}
+     * @throws NullPointerException     if {@code primitiveType} is null
+     * @throws IllegalArgumentException if {@code primitiveType} is not a primitive type
+     * @throws IllegalStateException    if no generator is registered for the type
      */
     public static PrimitiveArrayGenerators resolveForType(final Class<?> primitiveType) {
         requireNonNull(primitiveType);

--- a/src/main/java/de/cuioss/test/generator/impl/ShortObjectGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/ShortObjectGenerator.java
@@ -43,6 +43,7 @@ import de.cuioss.test.generator.TypedGenerator;
  *
  * @author Oliver Wolff
  * @see IntegerGenerator
+ * @since 1.0
  */
 public class ShortObjectGenerator implements TypedGenerator<Short> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/StringGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/StringGenerator.java
@@ -21,11 +21,12 @@ import de.cuioss.test.generator.internal.RandomContext;
 /**
  * Generates random {@link String} values with configurable length and character set.
  * <p>
- * The default configuration generates strings of 0-30 characters from the Basic Latin
- * and Latin-1 Supplement unicode blocks.
+ * The default configuration generates strings of 0-30 characters from the printable Basic
+ * Latin range (0x20-0x7E).
  * </p>
  *
  * @author Oliver Wolff
+ * @since 1.0
  */
 public class StringGenerator implements TypedGenerator<String> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/URLGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/URLGenerator.java
@@ -27,7 +27,7 @@ import java.net.URL;
  * 
  * <p>URL characteristics:</p>
  * <ul>
- *   <li>All URLs are valid and accessible</li>
+ *   <li>All URLs are syntactically valid</li>
  *   <li>Mix of HTTP and HTTPS protocols</li>
  *   <li>Includes popular tech, development, and reference sites</li>
  * </ul>
@@ -51,6 +51,7 @@ import java.net.URL;
  *
  * @author Oliver Wolff
  * @see URL
+ * @since 1.0
  */
 public class URLGenerator implements TypedGenerator<URL> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/UniqueValuesGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/UniqueValuesGenerator.java
@@ -27,6 +27,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @param <T> the type of values to generate
  * @author Oliver Wolff
+ * @since 1.0
  */
 public class UniqueValuesGenerator<T> implements TypedGenerator<T> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/ZoneOffsetGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/ZoneOffsetGenerator.java
@@ -64,6 +64,7 @@ import static java.time.ZoneId.getAvailableZoneIds;
  * @see ZoneOffset
  * @see ZoneId
  * @see LocalDateTime
+ * @since 1.0
  */
 public class ZoneOffsetGenerator implements TypedGenerator<ZoneOffset> {
 

--- a/src/main/java/de/cuioss/test/generator/impl/ZonedDateTimeGenerator.java
+++ b/src/main/java/de/cuioss/test/generator/impl/ZonedDateTimeGenerator.java
@@ -59,6 +59,7 @@ import static de.cuioss.test.generator.Generators.integers;
  * @see ZonedDateTime
  * @see Generators#dates()
  * @see Generators#zoneIds()
+ * @since 1.0
  */
 public class ZonedDateTimeGenerator implements TypedGenerator<ZonedDateTime> {
 
@@ -89,56 +90,56 @@ public class ZonedDateTimeGenerator implements TypedGenerator<ZonedDateTime> {
     }
 
     /**
-     * @return value of ZonedDateTime one hour ago
+     * @return value of ZonedDateTime between 1 and 10 minutes ago
      */
     public static ZonedDateTime someMinutesAgo() {
         return now().minusMinutes(SOME_INT.next());
     }
 
     /**
-     * @return value of ZonedDateTime one hour ago
+     * @return value of ZonedDateTime between 1 and 10 hours ago
      */
     public static ZonedDateTime someHoursAgo() {
         return now().minusHours(SOME_INT.next());
     }
 
     /**
-     * @return value of ZonedDateTime one day ago
+     * @return value of ZonedDateTime between 1 and 10 days ago
      */
     public static ZonedDateTime someDaysAgo() {
         return now().minusDays(SOME_INT.next());
     }
 
     /**
-     * @return value of ZonedDateTime one week ago
+     * @return value of ZonedDateTime between 1 and 10 weeks ago
      */
     public static ZonedDateTime someWeeksAgo() {
         return now().minusWeeks(SOME_INT.next());
     }
 
     /**
-     * @return value of ZonedDateTime one month ago
+     * @return value of ZonedDateTime between 1 and 10 months ago
      */
     public static ZonedDateTime someMonthsAgo() {
         return now().minusMonths(SOME_INT.next());
     }
 
     /**
-     * @return value of ZonedDateTime one year ago
+     * @return value of ZonedDateTime between 1 and 10 years ago
      */
     public static ZonedDateTime someYearsAgo() {
         return now().minusYears(SOME_INT.next());
     }
 
     /**
-     * @return value of ZonedDateTime with date somewhere 10 years ago
+     * @return value of ZonedDateTime exactly 10 years ago
      */
     public static ZonedDateTime lastTenYearsAgo() {
         return now().minusYears(10);
     }
 
     /**
-     * @return value of ZonedDateTime with date somewhere lastMonth
+     * @return value of ZonedDateTime exactly one month ago
      */
     public static ZonedDateTime lastMonthAgo() {
         return now().minusMonths(1);

--- a/src/main/java/de/cuioss/test/generator/impl/package-info.java
+++ b/src/main/java/de/cuioss/test/generator/impl/package-info.java
@@ -50,7 +50,7 @@
  * <h3>String and URL Generators</h3>
  * <ul>
  *   <li>{@link de.cuioss.test.generator.impl.StringGenerator} - Configurable string generation with charset and length control</li>
- *   <li>{@link de.cuioss.test.generator.impl.NonBlankStringGenerator} - Non-empty string generation</li>
+ *   <li>{@link de.cuioss.test.generator.impl.NonBlankStringGenerator} - Non-blank string generation</li>
  *   <li>{@link de.cuioss.test.generator.impl.URLGenerator} - Valid URL generation from predefined sets</li>
  * </ul>
  *
@@ -73,25 +73,18 @@
  * var stringGen = new NonBlankStringGenerator();
  * String value = stringGen.next();
  * 
- * // Collection generation
- * TypedGenerator&lt;Integer&gt; intGen = Generators.integers(1, 100);
- * var collectionGen = new CollectionGenerator&lt;&gt;(intGen);
- * List&lt;Integer&gt; list = collectionGen.list(5);
- * 
  * // Date/Time generation with zones
  * var dateTimeGen = new ZonedDateTimeGenerator();
- * ZonedDateTime future = dateTimeGen.future();
- * 
+ * ZonedDateTime dateTime = dateTimeGen.next();
+ *
  * // Numeric generation with ranges
  * var floatGen = new FloatObjectGenerator(0.0f, 100.0f);
  * Float number = floatGen.next();
- * 
- * // Create a generator for integers
+ *
+ * // Wrap a generator in a collection generator
  * TypedGenerator&lt;Integer&gt; intGen = Generators.integers(1, 100);
- * 
- * // Wrap it in a collection generator
  * var collectionGen = new CollectionGenerator&lt;&gt;(intGen);
- * 
+ *
  * // Generate lists and sets
  * List&lt;Integer&gt; list = collectionGen.list(5);  // List of 5 integers
  * Set&lt;Integer&gt; set = collectionGen.set(3);     // Set of 3 integers

--- a/src/main/java/de/cuioss/test/generator/junit/EnableGeneratorController.java
+++ b/src/main/java/de/cuioss/test/generator/junit/EnableGeneratorController.java
@@ -45,7 +45,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *     void shouldGenerateData() {
  *         var generator = new CollectionGenerator&lt;&gt;(Generators.strings());
  *         var result = generator.list(5);
- *         assertThat(result).hasSize(5);
+ *         assertEquals(5, result.size());
  *     }
  * }
  * }

--- a/src/main/java/de/cuioss/test/generator/junit/package-info.java
+++ b/src/main/java/de/cuioss/test/generator/junit/package-info.java
@@ -37,9 +37,9 @@
  * class MyGeneratorTest {
  *     @Test
  *     void shouldGenerateTestData() {
- *         var generator = new CollectionGenerator&lt;?&gt;(Generators.strings());
+ *         var generator = new CollectionGenerator<>(Generators.strings());
  *         var result = generator.list(5);
- *         assertThat(result).hasSize(5);
+ *         assertEquals(5, result.size());
  *     }
  * }
  * }

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorsSource.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorsSource.java
@@ -128,7 +128,7 @@ import java.lang.annotation.Target;
  * </pre>
  * 
  * @author Oliver Wolff
- * @since 2.0
+ * @since 2.3
  * @see TypedGenerator
  * @see Generators
  * @see GeneratorType
@@ -199,9 +199,23 @@ public @interface GeneratorsSource {
     /**
      * Number of instances to generate.
      * This controls how many test invocations will occur with different generated values.
-     * 
+     *
      * @return the number of instances to generate, defaults to 1
      */
     int count() default 1;
+
+    /**
+     * Optional seed for reproducible tests.
+     * <p>
+     * When set to a value other than {@code -1}, this seed is applied for generation instead
+     * of the seed managed by
+     * {@link de.cuioss.test.generator.junit.GeneratorControllerExtension} (or a
+     * {@code @GeneratorSeed} annotation). This is useful for tests that need specific
+     * generated values regardless of the global seed configuration.
+     * </p>
+     *
+     * @return the seed to use, or {@code -1} (the default) to use the managed seed
+     */
+    long seed() default -1L;
 
 }

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorsSourceArgumentsProvider.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/GeneratorsSourceArgumentsProvider.java
@@ -54,6 +54,7 @@ public class GeneratorsSourceArgumentsProvider extends AbstractTypedGeneratorArg
     private String low;
     private String high;
     private int count;
+    private long seed;
 
     @Override
     public void accept(GeneratorsSource annotation) {
@@ -64,6 +65,7 @@ public class GeneratorsSourceArgumentsProvider extends AbstractTypedGeneratorArg
         low = annotation.low();
         high = annotation.high();
         count = Math.max(1, annotation.count());
+        seed = annotation.seed();
     }
 
     @Override
@@ -74,7 +76,7 @@ public class GeneratorsSourceArgumentsProvider extends AbstractTypedGeneratorArg
 
     @Override
     protected long getSeed() {
-        return -1L;
+        return seed;
     }
 
     @Override

--- a/src/main/java/de/cuioss/test/generator/junit/parameterized/package-info.java
+++ b/src/main/java/de/cuioss/test/generator/junit/parameterized/package-info.java
@@ -30,36 +30,40 @@
  * </p>
  * 
  * <h3>Common Parameters</h3>
- * 
+ *
  * <p>
- * All annotations in this package support the following common parameters:
+ * The annotations in this package share the following parameters:
  * </p>
- * 
+ *
  * <ul>
  *   <li><strong>count</strong> - Specifies the number of test instances to generate.
  *       This controls how many test invocations will occur with different generated values.
  *       Defaults to 1 in most annotations.</li>
- *   <li><strong>seed</strong> - An optional seed value for reproducible tests.
- *       When specified (not -1), this seed will be used for the generator instead of the
- *       seed managed by {@link de.cuioss.test.generator.junit.GeneratorControllerExtension}.
- *       This is useful for tests that need specific generated values regardless of
- *       the global seed configuration.</li>
+ *   <li><strong>seed</strong> - An optional seed value for reproducible tests, supported by
+ *       {@link de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource} and
+ *       {@link de.cuioss.test.generator.junit.parameterized.GeneratorsSource}.
+ *       When specified (not -1), this seed is used for the generator instead of the seed
+ *       managed by {@link de.cuioss.test.generator.junit.GeneratorControllerExtension}.
+ *       The other annotations rely on {@code @GeneratorSeed} for reproducibility.</li>
  * </ul>
- * 
+ *
  * <h3>Available Annotations</h3>
- * 
+ *
  * <p>
  * The package provides the following annotations for different use cases:
  * </p>
- * 
+ *
  * <ul>
- *   <li>{@link de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource} - 
+ *   <li>{@link de.cuioss.test.generator.junit.parameterized.GeneratorsSource} -
+ *       Uses a {@link de.cuioss.test.generator.junit.parameterized.GeneratorType} from the
+ *       {@link de.cuioss.test.generator.Generators} factory (recommended).</li>
+ *   <li>{@link de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource} -
  *       Uses a TypedGenerator implementation directly via its class.</li>
- *   <li>{@link de.cuioss.test.generator.junit.parameterized.TypeGeneratorMethodSource} - 
+ *   <li>{@link de.cuioss.test.generator.junit.parameterized.TypeGeneratorMethodSource} -
  *       Uses a method that returns a configured TypedGenerator instance.</li>
- *   <li>{@link de.cuioss.test.generator.junit.parameterized.TypeGeneratorFactorySource} - 
+ *   <li>{@link de.cuioss.test.generator.junit.parameterized.TypeGeneratorFactorySource} -
  *       Uses a factory class with a static method to create a TypedGenerator instance.</li>
- *   <li>{@link de.cuioss.test.generator.junit.parameterized.CompositeTypeGeneratorSource} - 
+ *   <li>{@link de.cuioss.test.generator.junit.parameterized.CompositeTypeGeneratorSource} -
  *       Combines multiple TypedGenerator implementations to generate combinations of values.</li>
  * </ul>
  * 

--- a/src/site/asciidoc/about.adoc
+++ b/src/site/asciidoc/about.adoc
@@ -61,8 +61,8 @@ Central factory for `TypedGenerator` for most java-built-in types and wrappers f
  assertNotNull(Generators.fixedValues(String.class, "https://cuioss.de", "https://www.heise.de", "http://getbootstrap.com").next());
  
  assertEquals(Temporal.class, Generators.temporals().getType());
- assertNotNull(Generators.enumValues(PropertyMemberInfo.class).next());
- assertEquals(PropertyMemberInfo.class, Generators.enumValues(PropertyMemberInfo.class).getType());
+ assertNotNull(Generators.enumValues(TimeUnit.class).next());
+ assertEquals(TimeUnit.class, Generators.enumValues(TimeUnit.class).getType());
 ----
 
 === CollectionGenerator
@@ -90,7 +90,7 @@ Sample output:
 ----
 GeneratorController seed was 4711L.
 Use a fixed seed by applying @GeneratorSeed(4711L) for the method/class,
-or by using the system property '-Dio.cui.test.generator.seed=4711'
+or by using the system property '-Dde.cuioss.test.generator.seed=4711'
 ----
 
 === GeneratorSeed

--- a/src/test/java/de/cuioss/test/generator/junit/parameterized/GeneratorsSourceSeedTest.java
+++ b/src/test/java/de/cuioss/test/generator/junit/parameterized/GeneratorsSourceSeedTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.generator.junit.parameterized;
+
+import de.cuioss.test.generator.Generators;
+import de.cuioss.test.generator.internal.RandomContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("@GeneratorsSource seed attribute")
+class GeneratorsSourceSeedTest {
+
+    @Test
+    @DisplayName("applies the configured seed so generation is reproducible")
+    void shouldHonorSeedAttribute() throws Exception {
+        GeneratorsSource annotation = createMock(GeneratorsSource.class);
+        expect(annotation.generator()).andReturn(GeneratorType.INTEGERS).anyTimes();
+        expect(annotation.minSize()).andReturn(0).anyTimes();
+        expect(annotation.maxSize()).andReturn(10).anyTimes();
+        expect(annotation.low()).andReturn("1").anyTimes();
+        expect(annotation.high()).andReturn("100").anyTimes();
+        expect(annotation.count()).andReturn(3).anyTimes();
+        expect(annotation.seed()).andReturn(42L).anyTimes();
+        replay(annotation);
+
+        var provider = new GeneratorsSourceArgumentsProvider();
+        provider.accept(annotation);
+        assertEquals(42L, provider.getSeed());
+
+        List<Object> produced = provider.provideArguments(null, null)
+                .map(args -> args.get()[0]).toList();
+
+        // Baseline generated directly from the same seed, in the same order.
+        RandomContext.setSeed(42L);
+        var generator = Generators.integers(1, 100);
+        List<Object> baseline = List.of(generator.next(), generator.next(), generator.next());
+
+        assertEquals(baseline, produced, "The seed attribute must drive reproducible generation");
+        verify(annotation);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the documentation defects from `doc/review-26-07-04.md` (PR 6 of 7). Lands after PR 2/4/5 so the docs describe the decided behavior.

- **E-1 / E-2** — CLAUDE.md: collapse the two contradictory Git-workflow blocks into one sequence; drop the non-existent `cui-java-tools` dependency (actual: JUnit 5, Lombok; EasyMock test-only).
- **E-3** — add the documented `seed()` attribute (default `-1L`) to `@GeneratorsSource` and wire it through `GeneratorsSourceArgumentsProvider`, so the `seed = 42L` example now compiles and works.
- **E-4** — parameterized `package-info`: correct the "all annotations support seed" claim and add the missing `@GeneratorsSource` list entry.
- **E-5 / E-6** — `about.adoc`: fix the replay property name (`de.cuioss.test.generator.seed`) and use `TimeUnit.class` in the enum example.
- **E-7** — `junit/package-info` and `EnableGeneratorController`: valid `<>` generics and JUnit (not AssertJ) assertions in examples.
- **E-8** — README: add a version/BOM note to the Maven coordinates.
- **E-9** — align `@GeneratorsSource` `@since` to `2.3` and add `@since` tags to the public `impl` classes.
- **E-10 / E-11** — `Generators`: `fixedValues` example asserts membership (random selection, not cycling); fix `enumValuesIfAvailable`/`strings()`/`fixedValues`/`longs()` tags.
- **E-12** — `CollectionGenerator`: fix the `next()` example and garbled constructor param docs.
- **E-13** — `ZonedDateTimeGenerator`: correct the `some*Ago`/`last*` `@return` docs (1–10 units / exact offsets).
- **E-14** — `impl/package-info`: replace the non-existent `future()` call, fix "non-blank", deduplicate the snippet.
- **E-15** — `URLGenerator`: drop the "and accessible" claim.
- **E-16** — qualify the thread-safe/reproducible claims (`Generators`, `UUIDStringGenerator`, `domain/package-info`).
- **E-17** — `TypedGenerator.getType()`: document the NPE-on-null and the draw-consuming side effect.
- **E-18** — `StringGenerator`: correct the default character-range doc (printable Basic Latin, 0x20-0x7E).
- **E-19** — `PrimitiveArrayGenerators`: document `resolveForType`'s IAE/NPE and fix the typo.

## Test
`@GeneratorsSource` seed attribute drives reproducible generation (E-3).

## Verification
`./mvnw -Ppre-commit clean install` — green, clean tree. `./mvnw javadoc:javadoc` — no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhVybFv6iGrJNXo5Ekg5YA)_